### PR TITLE
feat: task 05 — TTL cache with getOrFetch for rate-limited APIs

### DIFF
--- a/src/shared/__tests__/cache.test.ts
+++ b/src/shared/__tests__/cache.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { TtlCache } from "../cache.js";
+
+describe("TtlCache", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns cached value within TTL", () => {
+    const cache = new TtlCache<string>(60_000);
+    cache.set("key1", "value1");
+    expect(cache.get("key1")).toBe("value1");
+  });
+
+  it("returns undefined after TTL expires", () => {
+    const cache = new TtlCache<string>(60_000);
+    cache.set("key1", "value1");
+    vi.advanceTimersByTime(61_000);
+    expect(cache.get("key1")).toBeUndefined();
+  });
+
+  it("returns undefined for missing key", () => {
+    const cache = new TtlCache<string>(60_000);
+    expect(cache.get("missing")).toBeUndefined();
+  });
+
+  it("getOrFetch returns cached value if present", async () => {
+    const cache = new TtlCache<string>(60_000);
+    cache.set("key1", "cached");
+    const fetcher = vi.fn().mockResolvedValue("fresh");
+    const result = await cache.getOrFetch("key1", fetcher);
+    expect(result).toBe("cached");
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("getOrFetch calls fetcher if cache miss", async () => {
+    const cache = new TtlCache<string>(60_000);
+    const fetcher = vi.fn().mockResolvedValue("fresh");
+    const result = await cache.getOrFetch("key1", fetcher);
+    expect(result).toBe("fresh");
+    expect(fetcher).toHaveBeenCalledOnce();
+  });
+
+  it("getOrFetch calls fetcher if cache expired", async () => {
+    const cache = new TtlCache<string>(60_000);
+    cache.set("key1", "stale");
+    vi.advanceTimersByTime(61_000);
+    const fetcher = vi.fn().mockResolvedValue("fresh");
+    const result = await cache.getOrFetch("key1", fetcher);
+    expect(result).toBe("fresh");
+  });
+});

--- a/src/shared/cache.ts
+++ b/src/shared/cache.ts
@@ -1,0 +1,38 @@
+interface CacheEntry<T> {
+  value: T;
+  expiresAt: number;
+}
+
+export class TtlCache<T> {
+  private store = new Map<string, CacheEntry<T>>();
+  private readonly ttlMs: number;
+
+  constructor(ttlMs: number) {
+    this.ttlMs = ttlMs;
+  }
+
+  get(key: string): T | undefined {
+    const entry = this.store.get(key);
+    if (!entry) return undefined;
+    if (Date.now() > entry.expiresAt) {
+      this.store.delete(key);
+      return undefined;
+    }
+    return entry.value;
+  }
+
+  set(key: string, value: T): void {
+    this.store.set(key, {
+      value,
+      expiresAt: Date.now() + this.ttlMs,
+    });
+  }
+
+  async getOrFetch(key: string, fetcher: () => Promise<T>): Promise<T> {
+    const cached = this.get(key);
+    if (cached !== undefined) return cached;
+    const value = await fetcher();
+    this.set(key, value);
+    return value;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `src/shared/cache.ts` with generic `TtlCache<T>` class
- `get(key)` / `set(key, value)` with lazy TTL expiry on read
- `getOrFetch(key, fetcher)` — returns cached value or calls async fetcher
- 6 tests covering: cache hit, miss, TTL expiry, getOrFetch (cached/miss/expired)

## Triple Review — All APPROVED
- **Senior Engineer:** Clean generic class, lazy eviction on `get()`, proper async `getOrFetch` pattern
- **Architect:** Self-contained utility, no external deps, matches design for rate-limited API caching
- **QA:** 6/6 tests pass using `vi.useFakeTimers()` for deterministic TTL testing

## Test plan
- [x] `npx vitest run src/shared/__tests__/cache.test.ts` — 6/6 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>