### PR TITLE
feat: task 07 — MCP server entry point

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "stock-scanner": {
+    "command": "node",
+    "args": ["${CLAUDE_PLUGIN_ROOT}/dist/index.js"],
+    "env": {
+      "FINNHUB_API_KEY": "${FINNHUB_API_KEY}",
+      "ALPHA_VANTAGE_API_KEY": "${ALPHA_VANTAGE_API_KEY}"
+    }
+  }
+}

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { parseConfig } from "../config.js";
+import { resolveEnabledModules } from "../registry.js";
+import type { ModuleDefinition, ToolDefinition } from "../shared/types.js";
+import { successResult } from "../shared/types.js";
+import { z } from "zod";
+
+describe("server module wiring", () => {
+  const mockTool: ToolDefinition = {
+    name: "test_tool",
+    description: "A test tool",
+    inputSchema: { symbol: z.string() },
+    handler: async () => successResult("ok"),
+  };
+
+  const mockModule: ModuleDefinition = {
+    name: "test-mod",
+    description: "Test",
+    requiredEnvVars: [],
+    tools: [mockTool],
+  };
+
+  it("registers tools from enabled modules", () => {
+    const config = parseConfig([]);
+    const enabled = resolveEnabledModules([mockModule], config.env);
+    const tools = enabled.flatMap((m) => m.tools);
+    expect(tools).toHaveLength(1);
+    expect(tools[0].name).toBe("test_tool");
+  });
+
+  it("wraps tool handler errors into error results", async () => {
+    const failingTool: ToolDefinition = {
+      name: "fail_tool",
+      description: "Fails",
+      inputSchema: {},
+      handler: async () => { throw new Error("boom"); },
+    };
+
+    try {
+      await failingTool.handler({});
+    } catch (err) {
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toBe("boom");
+    }
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,59 @@
-console.log('Stock Scanner MCP starting...');
+#!/usr/bin/env node
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { parseConfig } from "./config.js";
+import { resolveEnabledModules } from "./registry.js";
+import type { ModuleDefinition } from "./shared/types.js";
+
+// Modules will be imported here as they are built
+// import { createTradingviewModule } from "./modules/tradingview/index.js";
+
+function buildModules(_defaultExchange: string): ModuleDefinition[] {
+  return [
+    // Modules added here as implemented
+  ];
+}
+
+async function main() {
+  const config = parseConfig(process.argv.slice(2));
+  const allModules = buildModules(config.defaultExchange);
+  const enabled = resolveEnabledModules(allModules, config.env, config.enabledModules);
+
+  const server = new McpServer({
+    name: "stock-scanner",
+    version: "0.1.0",
+  });
+
+  for (const mod of enabled) {
+    for (const tool of mod.tools) {
+      server.registerTool(tool.name, {
+        description: tool.description,
+        inputSchema: tool.inputSchema,
+      }, async (params) => {
+        try {
+          return await tool.handler(params as Record<string, unknown>);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          return {
+            content: [{ type: "text" as const, text: `Error: ${message}` }],
+            isError: true,
+          };
+        }
+      });
+    }
+    console.error(`Registered ${mod.tools.length} tools from ${mod.name}`);
+  }
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error(
+    `stock-scanner MCP server running -- ${enabled.length} modules, ` +
+    `${enabled.reduce((n, m) => n + m.tools.length, 0)} tools`,
+  );
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 export interface ToolResult {
   content: Array<{ type: "text"; text: string }>;
   isError?: boolean;
+  [key: string]: unknown; // Index signature for MCP compatibility
 }
 
 export interface ToolDefinition {


### PR DESCRIPTION
Implemented the MCP server entry point using the @modelcontextprotocol/sdk. Includes dynamic tool registration from enabled modules, error wrapping, and .mcp.json configuration.