### PR TITLE
chore: prepare package for npm publishing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,14 @@
+# Source
+src/
+docs/
+.claude/
+
+# Config
+tsconfig.json
+vitest.config.ts
+.github/
+
+# Dev artifacts
+node_modules/
+coverage/
+*.tsbuildinfo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [0.1.0] - 2026-03-14
+
+### Added
+- TradingView stock scanning (scan, quote, technicals, top gainers, top volume, volume breakout)
+- TradingView crypto scanning (scan, quote, technicals, top gainers)
+- SEC EDGAR integration (search, company filings, company facts, insider trades, institutional holdings, ownership filings)
+- CoinGecko crypto data (coin details, trending, global stats)
+- Finnhub news and earnings (market news, company news, earnings calendar)
+- Alpha Vantage fundamentals (quote, daily history, company overview)
+- Modular architecture — modules auto-enable based on available API keys
+- CLI options for module selection and default exchange
+- In-memory TTL cache for rate-limited APIs
+- MCP prompts for stock analysis and intraday candidate workflows

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Yordan Yordanov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,36 +1,50 @@
 # stock-scanner-mcp
 
-A modular MCP (Model Context Protocol) server that provides Claude Code with stock and crypto market data via 21 tools across 6 data source modules.
+A modular MCP (Model Context Protocol) server that gives Claude Code real-time access to stock and crypto market data. Scan markets, check technicals, monitor insider trades, and track earnings — all from your terminal.
 
 ## Quick Start
-
-### As a Claude Code Plugin
-
-Add to your `.mcp.json`:
-```json
-{
-  "mcpServers": {
-    "stock-scanner": {
-      "command": "npx",
-      "args": ["stock-scanner-mcp"],
-      "env": {
-        "FINNHUB_API_KEY": "${FINNHUB_API_KEY}",
-        "ALPHA_VANTAGE_API_KEY": "${ALPHA_VANTAGE_API_KEY}"
-      }
-    }
-  }
-}
-```
-
-### Run Directly
 
 ```bash
 npx stock-scanner-mcp
 ```
 
-With specific modules only:
+Or install globally:
+
 ```bash
-npx stock-scanner-mcp --modules tradingview,coingecko
+npm install -g stock-scanner-mcp
+stock-scanner-mcp
+```
+
+## Setup with Claude Code
+
+Add to your Claude Code MCP config (`~/.claude.json` or project `.mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "stock-scanner": {
+      "command": "npx",
+      "args": ["-y", "stock-scanner-mcp"]
+    }
+  }
+}
+```
+
+### With API keys (optional, enables more tools):
+
+```json
+{
+  "mcpServers": {
+    "stock-scanner": {
+      "command": "npx",
+      "args": ["-y", "stock-scanner-mcp"],
+      "env": {
+        "FINNHUB_API_KEY": "your-key-here",
+        "ALPHA_VANTAGE_API_KEY": "your-key-here"
+      }
+    }
+  }
+}
 ```
 
 ## Modules
@@ -39,59 +53,63 @@ npx stock-scanner-mcp --modules tradingview,coingecko
 |--------|-------|---------|-------------|
 | tradingview | 6 | None | US stock scanner with real-time quotes, technicals, and screening |
 | tradingview-crypto | 4 | None | Crypto pair scanner with technicals and screening |
-| sec-edgar | 2 | None | SEC EDGAR filing search and company filings |
+| sec-edgar | 6 | None | SEC EDGAR filings, insider trades, institutional holdings, ownership |
 | coingecko | 3 | None | Crypto market data, trending coins, global stats |
 | finnhub | 3 | `FINNHUB_API_KEY` | Market news, company news, earnings calendar |
 | alpha-vantage | 3 | `ALPHA_VANTAGE_API_KEY` | Stock quotes, daily prices, company fundamentals |
 
 Modules auto-enable when their required environment variables are set. Modules with no required key are always enabled.
 
-## Tools Reference
+## Available Tools (25 total)
 
-### TradingView Stock Scanner (6 tools)
-
-| Tool | Description |
-|------|-------------|
-| `tradingview_scan` | Scan stocks with custom filters on any technical or fundamental indicator |
-| `tradingview_quote` | Get real-time quotes for specific stock symbols |
-| `tradingview_technicals` | Technical analysis summary (RSI, MACD, MAs, recommendation) |
-| `tradingview_top_gainers` | Top gaining stocks by percentage change |
-| `tradingview_top_volume` | Highest volume stocks |
-| `tradingview_volume_breakout` | Stocks with unusual volume breakouts |
-
-### TradingView Crypto Scanner (4 tools)
+### TradingView — Stock Scanning (no API key)
 
 | Tool | Description |
 |------|-------------|
-| `crypto_scan` | Scan crypto pairs with filters |
+| `tradingview_scan` | Scan US stocks with custom filters (price, RSI, volume, etc.) |
+| `tradingview_quote` | Real-time quotes for stock tickers |
+| `tradingview_technicals` | Technical indicators (RSI, MACD, moving averages, pivots) |
+| `tradingview_top_gainers` | Today's top gaining stocks |
+| `tradingview_top_volume` | Highest volume stocks today |
+| `tradingview_volume_breakout` | Stocks with unusual volume spikes |
+
+### TradingView — Crypto (no API key)
+
+| Tool | Description |
+|------|-------------|
+| `crypto_scan` | Scan crypto pairs with custom filters |
 | `crypto_quote` | Real-time crypto pair quotes |
 | `crypto_technicals` | Technical analysis for crypto pairs |
 | `crypto_top_gainers` | Top gaining crypto pairs |
 
-### SEC EDGAR (2 tools)
+### SEC EDGAR — Filings & Ownership (no API key)
 
 | Tool | Description |
 |------|-------------|
-| `edgar_search` | Full-text search SEC filings |
-| `edgar_company_filings` | Get recent filings for a company |
+| `edgar_search` | Full-text search across all SEC filings |
+| `edgar_company_filings` | Recent official filings (10-K, 10-Q, 8-K) |
+| `edgar_company_facts` | Financial metrics from XBRL data |
+| `edgar_insider_trades` | Insider buy/sell activity (Form 4) |
+| `edgar_institutional_holdings` | Institutional holdings (13F) |
+| `edgar_ownership_filings` | Major ownership changes (13D/13G) |
 
-### CoinGecko (3 tools)
-
-| Tool | Description |
-|------|-------------|
-| `coingecko_coin` | Detailed crypto info (use slug IDs: 'bitcoin', not 'BTC') |
-| `coingecko_trending` | Trending cryptocurrencies (top 7) |
-| `coingecko_global` | Global market stats (market cap, dominance) |
-
-### Finnhub (3 tools) — requires `FINNHUB_API_KEY`
+### CoinGecko — Crypto Intelligence (no API key)
 
 | Tool | Description |
 |------|-------------|
-| `finnhub_market_news` | Latest market news by category |
-| `finnhub_company_news` | Company-specific news with date range |
-| `finnhub_earnings_calendar` | Upcoming earnings reports |
+| `coingecko_coin` | Detailed crypto info by CoinGecko ID |
+| `coingecko_trending` | Top 7 trending cryptos by search volume |
+| `coingecko_global` | Global crypto market statistics |
 
-### Alpha Vantage (3 tools) — requires `ALPHA_VANTAGE_API_KEY`
+### Finnhub — News & Earnings (requires `FINNHUB_API_KEY`)
+
+| Tool | Description |
+|------|-------------|
+| `finnhub_market_news` | Latest market news articles |
+| `finnhub_company_news` | Company-specific news |
+| `finnhub_earnings_calendar` | Upcoming/historical earnings dates |
+
+### Alpha Vantage — Fundamentals (requires `ALPHA_VANTAGE_API_KEY`)
 
 | Tool | Description |
 |------|-------------|
@@ -105,29 +123,32 @@ Modules auto-enable when their required environment variables are set. Modules w
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `FINNHUB_API_KEY` | No | Enables Finnhub module. Get free key at [finnhub.io](https://finnhub.io) |
-| `ALPHA_VANTAGE_API_KEY` | No | Enables Alpha Vantage module. Get free key at [alphavantage.co](https://www.alphavantage.co/support/#api-key) |
+| `FINNHUB_API_KEY` | No | Enables Finnhub module ([get free key](https://finnhub.io/)) |
+| `ALPHA_VANTAGE_API_KEY` | No | Enables Alpha Vantage module ([get free key](https://www.alphavantage.co/support/#api-key)) |
 
-### CLI Arguments
+### CLI Options
 
-| Argument | Description |
-|----------|-------------|
-| `--modules` | Comma-separated list of modules to enable (default: all available) |
-| `--default-exchange` | Default exchange for symbol resolution (default: NASDAQ) |
+```bash
+stock-scanner-mcp --modules tradingview,sec-edgar    # Enable specific modules only
+stock-scanner-mcp --default-exchange NYSE             # Set default exchange
+```
+
+## Example Usage in Claude Code
+
+Once configured, just ask Claude naturally:
+
+- "What are the top gaining stocks today?"
+- "Show me technicals for AAPL"
+- "Any insider trades for TSLA in the last 30 days?"
+- "What's trending in crypto right now?"
+- "Find stocks with unusual volume today"
 
 ## Development
 
 ```bash
-# Install dependencies
 npm install
-
-# Build
 npm run build
-
-# Run tests
 npm test
-
-# Run locally
 node dist/index.js
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stock-scanner-mcp",
   "version": "0.1.0",
-  "description": "Claude Code Plugin for stock and crypto market data",
+  "description": "MCP server providing Claude Code with real-time stock and crypto market data, SEC filings, insider trades, and technical analysis",
   "type": "module",
   "bin": {
     "stock-scanner-mcp": "./dist/index.js"
@@ -11,19 +11,38 @@
     "dev": "tsup src/index.ts --format esm --watch",
     "test": "vitest run",
     "test:watch": "vitest",
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "prepublishOnly": "npm run build && npm test"
   },
   "files": [
     "dist"
   ],
   "keywords": [
     "mcp",
+    "model-context-protocol",
     "stock",
     "crypto",
     "tradingview",
-    "claude-code"
+    "sec-edgar",
+    "insider-trades",
+    "market-data",
+    "claude-code",
+    "claude",
+    "ai-tools"
   ],
+  "author": "Yordan Yordanov",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yyordanov-tradu/stock-scanner-mcp.git"
+  },
+  "homepage": "https://github.com/yyordanov-tradu/stock-scanner-mcp#readme",
+  "bugs": {
+    "url": "https://github.com/yyordanov-tradu/stock-scanner-mcp/issues"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
     "zod": "^3.24.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,16 @@
 #!/usr/bin/env node
 
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 import { parseConfig } from "./config.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const pkg = JSON.parse(readFileSync(join(__dirname, "..", "package.json"), "utf-8"));
 import { resolveEnabledModules } from "./registry.js";
 import type { ModuleDefinition } from "./shared/types.js";
 import { createTradingviewModule } from "./modules/tradingview/index.js";
@@ -39,7 +46,7 @@ async function main() {
 
   const server = new McpServer({
     name: "stock-scanner",
-    version: "0.1.0",
+    version: pkg.version,
   });
 
   for (const mod of enabled) {


### PR DESCRIPTION
## Summary
- Added MIT `LICENSE` file
- Added `.npmignore` — package ships only 5 files (15KB compressed)
- Updated `package.json` with `author`, `repository`, `homepage`, `bugs`, `engines >= 18`, `prepublishOnly` script, and expanded keywords
- `src/index.ts` now reads version from `package.json` instead of hardcoding `"0.1.0"`
- Updated `README.md` with accurate 25-tool count, setup instructions, and complete reference
- Added `CHANGELOG.md` following Keep a Changelog format

## Package contents (npm pack --dry-run)
```
LICENSE        1.1kB
README.md      5.1kB
dist/index.js 51.9kB
dist/index.d.ts  20B
package.json   1.4kB
Total: 15.2kB compressed
```

## What's left after merge
1. Make repo public: `gh repo edit --visibility public`
2. `npm login` (already done)
3. `npm publish --access public`

## Test plan
- [x] `npm run build` — clean build
- [x] `npm test` — 75/75 passing
- [x] `npm pack --dry-run` — only dist/, LICENSE, README, package.json included
- [x] No source code, docs, or test files in package

🤖 Generated with [Claude Code](https://claude.com/claude-code)