### PR TITLE
feat: top_losers tool + EDGAR ticker fix (#28, #31)

### DIFF
--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -33,7 +33,7 @@ describe("full module wiring", () => {
       "tradingview", "tradingview-crypto", "sec-edgar", "coingecko",
     ]);
     const totalTools = enabled.reduce((n, m) => n + m.tools.length, 0);
-    expect(totalTools).toBe(19); // 6 + 4 + 6 + 3
+    expect(totalTools).toBe(20); // 7 + 4 + 6 + 3
   });
 
   it("enables all 6 modules with all API keys", () => {
@@ -45,10 +45,10 @@ describe("full module wiring", () => {
     const enabled = resolveEnabledModules(modules, env);
     expect(enabled).toHaveLength(6);
     const totalTools = enabled.reduce((n, m) => n + m.tools.length, 0);
-    expect(totalTools).toBe(27); // 6 + 4 + 6 + 3 + 4 + 4
+    expect(totalTools).toBe(28); // 7 + 4 + 6 + 3 + 4 + 4
   });
 
-  it("all 27 tool names are unique", () => {
+  it("all 28 tool names are unique", () => {
     const env = {
       FINNHUB_API_KEY: "key",
       ALPHA_VANTAGE_API_KEY: "key",
@@ -56,7 +56,7 @@ describe("full module wiring", () => {
     const modules = buildAllModules(env);
     const enabled = resolveEnabledModules(modules, env);
     const allNames = enabled.flatMap((m) => m.tools.map((t) => t.name));
-    expect(new Set(allNames).size).toBe(27);
+    expect(new Set(allNames).size).toBe(28);
   });
 
   it("respects --modules filter", () => {

--- a/src/modules/sec-edgar/__tests__/client.test.ts
+++ b/src/modules/sec-edgar/__tests__/client.test.ts
@@ -95,6 +95,35 @@ describe("getCompanyFilings", () => {
     expect(calledUrl).toContain("q=APLD");
     expect(calledUrl).not.toContain("tickers=");
   });
+
+  it("backfills empty ticker field from input param", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        hits: {
+          hits: [
+            {
+              _id: "0001234567-24-000001",
+              _source: {
+                file_num: "001-12345",
+                file_date: "2024-03-15",
+                form_type: "10-K",
+                entity_name: "Applied Digital Corp",
+                tickers: "",
+                display_names: ["Applied Digital Corp"],
+                file_description: "Annual report",
+              },
+            },
+          ],
+        },
+      }),
+    });
+
+    const filings = await getCompanyFilings({ ticker: "apld" });
+
+    expect(filings).toHaveLength(1);
+    expect(filings[0].ticker).toBe("APLD");
+  });
 });
 
 describe("createSecEdgarModule", () => {

--- a/src/modules/sec-edgar/client.ts
+++ b/src/modules/sec-edgar/client.ts
@@ -104,11 +104,16 @@ export interface CompanyFilingsParams {
 export async function getCompanyFilings(
   params: CompanyFilingsParams,
 ): Promise<EdgarFiling[]> {
-  return searchFilings({
+  const filings = await searchFilings({
     query: params.ticker,
     forms: params.forms,
     limit: params.limit,
   });
+  const ticker = params.ticker.toUpperCase();
+  for (const f of filings) {
+    if (!f.ticker) f.ticker = ticker;
+  }
+  return filings;
 }
 
 export interface CompanyMetricValue {
@@ -350,20 +355,33 @@ export async function getInsiderTrades(ticker: string, limit = 10): Promise<Edga
  * Get recent institutional holdings reports (Form 13F) for a ticker or manager.
  */
 export async function getInstitutionalHoldings(query: string, limit = 10): Promise<EdgarFiling[]> {
-  return searchFilings({
+  const filings = await searchFilings({
     query,
     forms: ["13F-HR", "13F-HR/A", "13F-NT", "13F-NT/A"],
     limit,
   });
+  // Backfill ticker if query looks like a ticker symbol (short, alphanumeric)
+  if (/^[A-Za-z]{1,5}$/.test(query.trim())) {
+    const ticker = query.trim().toUpperCase();
+    for (const f of filings) {
+      if (!f.ticker) f.ticker = ticker;
+    }
+  }
+  return filings;
 }
 
 /**
  * Get recent significant ownership filings (13D, 13G) for a ticker.
  */
 export async function getOwnershipFilings(ticker: string, limit = 10): Promise<EdgarFiling[]> {
-  return searchFilings({
+  const filings = await searchFilings({
     query: ticker,
     forms: ["SC 13D", "SC 13D/A", "SC 13G", "SC 13G/A"],
     limit,
   });
+  const upperTicker = ticker.toUpperCase();
+  for (const f of filings) {
+    if (!f.ticker) f.ticker = upperTicker;
+  }
+  return filings;
 }

--- a/src/modules/tradingview/__tests__/scanner.test.ts
+++ b/src/modules/tradingview/__tests__/scanner.test.ts
@@ -82,6 +82,18 @@ describe("scanStocks", () => {
     expect(callBody.range).toEqual([0, 10]);
   });
 
+  it("uses custom sort when provided", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [] }),
+    });
+
+    await scanStocks({ columns: ["change", "close"], sort: { sortBy: "change", sortOrder: "asc" } });
+
+    const callBody = JSON.parse((fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body);
+    expect(callBody.sort).toEqual({ sortBy: "change", sortOrder: "asc" });
+  });
+
   it("applies timeframe suffix for non-daily timeframes", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
@@ -103,12 +115,13 @@ describe("createTradingviewModule", () => {
     const mod = createTradingviewModule();
     expect(mod.name).toBe("tradingview");
     expect(mod.requiredEnvVars).toEqual([]);
-    expect(mod.tools).toHaveLength(6);
+    expect(mod.tools).toHaveLength(7);
     expect(mod.tools.map((t) => t.name)).toEqual([
       "tradingview_scan",
       "tradingview_quote",
       "tradingview_technicals",
       "tradingview_top_gainers",
+      "tradingview_top_losers",
       "tradingview_top_volume",
       "tradingview_volume_breakout",
     ]);

--- a/src/modules/tradingview/index.ts
+++ b/src/modules/tradingview/index.ts
@@ -92,6 +92,27 @@ export function createTradingviewModule(): ModuleDefinition {
         }, metadata),
       },
       {
+        name: "tradingview_top_losers",
+        description: "Get today's top losing stocks by percentage change on a given exchange. Defaults to major US exchanges (NYSE, NASDAQ, AMEX) with market cap > $100M.",
+        inputSchema: {
+          exchange: z.string().optional().describe("Exchange (default: all US)"),
+          limit: z.number().optional().describe("Max results (default 20)"),
+        },
+        handler: withMetadata(async (input) => {
+          const filters = [
+            { left: "market_cap_basic", operation: "greater", right: 100_000_000 },
+          ];
+          const rows = await scanStocks({
+            exchange: input.exchange,
+            columns: ["close", "change", "change_abs", "volume", "name", "description", "market_cap_basic"],
+            filters,
+            limit: input.limit ?? 20,
+            sort: { sortBy: "change", sortOrder: "asc" },
+          });
+          return successResult(JSON.stringify(rows, null, 2));
+        }, metadata),
+      },
+      {
         name: "tradingview_top_volume",
         description: "Get stocks with the highest trading volume today. Defaults to major US exchanges.",
         inputSchema: {

--- a/src/modules/tradingview/scanner.ts
+++ b/src/modules/tradingview/scanner.ts
@@ -14,6 +14,7 @@ export interface ScanRequest {
   columns?: string[];
   timeframe?: string;
   limit?: number;
+  sort?: { sortBy: string; sortOrder: "asc" | "desc" };
 }
 
 export interface ScanRow {
@@ -47,7 +48,7 @@ export async function scanStocks(request: ScanRequest): Promise<ScanRow[]> {
     columns,
     options: { lang: "en" },
     range: [0, request.limit ?? 50],
-    sort: { sortBy: columns[0], sortOrder: "desc" },
+    sort: request.sort ?? { sortBy: columns[0], sortOrder: "desc" },
   };
 
   if (request.tickers) {


### PR DESCRIPTION
## Summary
- **#31 — Add `tradingview_top_losers` tool**: Mirrors `top_gainers` with ascending sort by `change%`. Added `sort` option to `ScanRequest` interface for flexible sorting.
- **#28 — Fix EDGAR empty ticker field**: Backfills ticker from input param in `getCompanyFilings`, `getOwnershipFilings`, and `getInstitutionalHoldings` when EFTS returns empty ticker. For `getInstitutionalHoldings`, only backfills when query looks like a ticker symbol (1-5 alpha chars).

## Changes
- `src/modules/tradingview/scanner.ts` — Added optional `sort` field to `ScanRequest`
- `src/modules/tradingview/index.ts` — Added `tradingview_top_losers` tool (7 tools total now)
- `src/modules/sec-edgar/client.ts` — Ticker backfill in 3 functions
- Tests updated: 2 new tests, tool counts 27→28

## Test plan
- [x] All 77 tests pass (75 existing + 2 new)
- [ ] Gemini cross-review
- [ ] Live test: `tradingview_top_losers` returns stocks sorted by worst % change
- [ ] Live test: `edgar_company_filings` for APLD returns ticker="APLD" not ""

🤖 Generated with [Claude Code](https://claude.com/claude-code)