### PR TITLE
fix: pass symbol param to Finnhub earnings API server-side

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,10 +1,12 @@
 {
-  "stock-scanner": {
-    "command": "node",
-    "args": ["${CLAUDE_PLUGIN_ROOT}/dist/index.js"],
-    "env": {
-      "FINNHUB_API_KEY": "${FINNHUB_API_KEY}",
-      "ALPHA_VANTAGE_API_KEY": "${ALPHA_VANTAGE_API_KEY}"
+  "mcpServers": {
+    "stock-scanner": {
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/dist/index.js"],
+      "env": {
+        "FINNHUB_API_KEY": "${FINNHUB_API_KEY}",
+        "ALPHA_VANTAGE_API_KEY": "${ALPHA_VANTAGE_API_KEY}"
+      }
     }
   }
 }

--- a/src/modules/finnhub/client.ts
+++ b/src/modules/finnhub/client.ts
@@ -117,13 +117,19 @@ export async function getEarningsCalendar(
   apiKey: string,
   from: string,
   to: string,
+  symbol?: string,
 ): Promise<EarningsEvent[]> {
-  const cacheKey = `earnings:${from}:${to}`;
+  const cacheKey = `earnings:${from}:${to}:${symbol ?? "all"}`;
   const cached = cache.get(cacheKey);
   if (cached) return cached as EarningsEvent[];
 
+  let url = `${BASE_URL}/calendar/earnings?from=${from}&to=${to}`;
+  if (symbol) {
+    url += `&symbol=${encodeURIComponent(symbol)}`;
+  }
+
   const data = await httpGet<{ earningsCalendar: EarningsEvent[] }>(
-    `${BASE_URL}/calendar/earnings?from=${from}&to=${to}`,
+    url,
     { headers: { "X-Finnhub-Token": apiKey } },
   );
 

--- a/src/modules/finnhub/index.ts
+++ b/src/modules/finnhub/index.ts
@@ -64,20 +64,19 @@ export function createFinnhubModule(apiKey: string): ModuleDefinition {
       limit: z.number().optional().describe("Max results to return (default: 20, max: 100)"),
     }),
     handler: withMetadata(async (params) => {
+      const symbol = params.symbol
+        ? resolveTicker(params.symbol as string).ticker
+        : undefined;
+
       const results = await getEarningsCalendar(
         apiKey,
         params.from as string,
         params.to as string,
+        symbol,
       );
-      
-      let filtered = results;
-      if (params.symbol) {
-        const s = resolveTicker(params.symbol as string).ticker;
-        filtered = results.filter(r => r.symbol === s);
-      }
 
       const limit = Math.min((params.limit as number) ?? 20, 100);
-      const capped = filtered.slice(0, limit);
+      const capped = results.slice(0, limit);
 
       return successResult(JSON.stringify(capped, null, 2));
     }, metadata),


### PR DESCRIPTION
## Summary
- **Earnings calendar overflow fix**: passes optional `symbol` param directly to the Finnhub API instead of fetching the entire market and filtering client-side. A 1-week range was returning 84K+ chars causing token overflow.
- **MCP config fix**: wraps `.mcp.json` in the required `mcpServers` key for correct project-level MCP config format.

## Changes
- `src/modules/finnhub/client.ts` — `getEarningsCalendar()` now accepts optional `symbol` and appends it to the API URL
- `src/modules/finnhub/index.ts` — handler resolves ticker and passes to client instead of post-filtering
- `.mcp.json` — added `mcpServers` wrapper

## Test plan
- [x] `npm run build` passes
- [x] All 82 tests pass
- [ ] Manual: call `finnhub_earnings_calendar` with `symbol: "AAPL"` — should return small response
- [ ] Manual: call without symbol — should still work with default limit of 20

🤖 Generated with [Claude Code](https://claude.com/claude-code)