### PR TITLE
fix: throw on empty Alpha Vantage response instead of crashing (#58)

### DIFF
--- a/src/modules/alpha-vantage/__tests__/client.test.ts
+++ b/src/modules/alpha-vantage/__tests__/client.test.ts
@@ -117,38 +117,6 @@ describe("getOverview", () => {
   });
 });
 
-describe("checkAvResponse - empty response handling", () => {
-  beforeEach(() => {
-    vi.stubGlobal("fetch", vi.fn());
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it("throws meaningful error when API returns null", async () => {
-    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
-      ok: true,
-      json: async () => null,
-    });
-
-    await expect(getDailyPrices("key", "AAPL")).rejects.toThrow(
-      "Alpha Vantage API returned empty response",
-    );
-  });
-
-  it("throws meaningful error when API returns undefined", async () => {
-    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
-      ok: true,
-      json: async () => undefined,
-    });
-
-    await expect(getQuote("key", "ZZZZ")).rejects.toThrow(
-      "Alpha Vantage API returned empty response",
-    );
-  });
-});
-
 describe("createAlphaVantageModule", () => {
   it("returns module with 5 tools and requires ALPHA_VANTAGE_API_KEY", async () => {
     const { createAlphaVantageModule } = await import("../index.js");

--- a/src/modules/alpha-vantage/__tests__/errors.test.ts
+++ b/src/modules/alpha-vantage/__tests__/errors.test.ts
@@ -65,4 +65,26 @@ describe("Alpha Vantage error handling", () => {
 
     await expect(getOverview("key", "YYYY")).rejects.toThrow(/Alpha Vantage Rate Limit/);
   });
+
+  it("throws meaningful error when API returns null", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => null,
+    });
+
+    await expect(getDailyPrices("key", "NULLTEST")).rejects.toThrow(
+      "Alpha Vantage API returned empty response",
+    );
+  });
+
+  it("throws meaningful error when API returns undefined", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => undefined,
+    });
+
+    await expect(getQuote("key", "UNDEFTEST")).rejects.toThrow(
+      "Alpha Vantage API returned empty response",
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- `checkAvResponse()` silently returned on null/undefined data, causing `Object.entries(undefined)` crash downstream
- Now throws a clear error: "Alpha Vantage API returned empty response"
- Added 2 tests for null and undefined API responses

Closes #58

## Test plan
- [x] `tsc --noEmit` passes
- [x] 87 tests pass (2 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)