### PR TITLE
fix: detect empty Alpha Vantage overview response instead of returning zeros (#59)

### DIFF
--- a/src/modules/alpha-vantage/__tests__/client.test.ts
+++ b/src/modules/alpha-vantage/__tests__/client.test.ts
@@ -84,19 +84,6 @@ describe("getOverview", () => {
     vi.restoreAllMocks();
   });
 
-  it("throws when response has Symbol but no meaningful data", async () => {
-    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        Symbol: "AAPL",
-      }),
-    });
-
-    await expect(getOverview("key", "AAPL")).rejects.toThrow(
-      "Alpha Vantage returned empty overview for AAPL (possible rate limit)",
-    );
-  });
-
   it("fetches company overview", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,

--- a/src/modules/alpha-vantage/__tests__/errors.test.ts
+++ b/src/modules/alpha-vantage/__tests__/errors.test.ts
@@ -42,4 +42,27 @@ describe("Alpha Vantage error handling", () => {
 
     await expect(getOverview("key", "INVALID")).rejects.toThrow(/Alpha Vantage Error/);
   });
+
+  it("throws on overview with Symbol but no real data", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ Symbol: "AAPL" }),
+    });
+
+    await expect(getOverview("key", "ZZZZ")).rejects.toThrow(/Alpha Vantage Rate Limit/);
+  });
+
+  it("throws on overview with 'None' string values (rate limited)", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        Symbol: "AAPL",
+        Name: "Apple Inc.",
+        MarketCapitalization: "None",
+        PERatio: "None",
+      }),
+    });
+
+    await expect(getOverview("key", "YYYY")).rejects.toThrow(/Alpha Vantage Rate Limit/);
+  });
 });

--- a/src/modules/alpha-vantage/client.ts
+++ b/src/modules/alpha-vantage/client.ts
@@ -150,8 +150,9 @@ export async function getOverview(apiKey: string, symbol: string): Promise<Compa
   if (!data || !data.Symbol) {
     throw new Error(`Company overview not found for ${symbol}`);
   }
-  if (!data.MarketCapitalization && !data.Name) {
-    throw new Error(`Alpha Vantage returned empty overview for ${symbol} (possible rate limit)`);
+  const mcap = data.MarketCapitalization;
+  if (!data.Name || !mcap || mcap === "None" || mcap === "-" || mcap === "0") {
+    throw new Error(`Alpha Vantage Rate Limit: empty overview for ${symbol}`);
   }
 
   const overview: CompanyOverview = {


### PR DESCRIPTION
## Summary
- `getOverview()` now throws when response has Symbol but no actual data (rate limiting scenario)
- Previously `parseFloat(undefined)` → NaN → `|| 0` silently returned zeros for all fields
- Added test for empty overview detection

Closes #59

## Test plan
- [x] `tsc --noEmit` passes
- [x] 86 tests pass (1 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)