### PR TITLE
chore: remove finnhub_analyst_ratings tool (premium-only endpoint) (#60)

### DIFF
--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -45,10 +45,10 @@ describe("full module wiring", () => {
     const enabled = resolveEnabledModules(modules, env);
     expect(enabled).toHaveLength(6);
     const totalTools = enabled.reduce((n, m) => n + m.tools.length, 0);
-    expect(totalTools).toBe(30); // 7 + 4 + 6 + 3 + 5 + 5
+    expect(totalTools).toBe(29); // 7 + 4 + 6 + 3 + 4 + 5
   });
 
-  it("all 30 tool names are unique", () => {
+  it("all 29 tool names are unique", () => {
     const env = {
       FINNHUB_API_KEY: "key",
       ALPHA_VANTAGE_API_KEY: "key",
@@ -56,7 +56,7 @@ describe("full module wiring", () => {
     const modules = buildAllModules(env);
     const enabled = resolveEnabledModules(modules, env);
     const allNames = enabled.flatMap((m) => m.tools.map((t) => t.name));
-    expect(new Set(allNames).size).toBe(30);
+    expect(new Set(allNames).size).toBe(29);
   });
 
   it("respects --modules filter", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,12 +53,12 @@ OPTIONS
   --modules <list>        Comma-separated modules to enable (default: all available)
   --default-exchange <ex> Default exchange for symbol resolution (default: NASDAQ)
 
-MODULES (30 tools total)
+MODULES (29 tools total)
   tradingview        7 tools  Stock scanning, quotes, technicals       (no key)
   tradingview-crypto 4 tools  Crypto pair scanning and technicals      (no key)
   sec-edgar          6 tools  SEC filings, insider trades, holdings    (no key)
   coingecko          3 tools  Crypto market data and trending          (no key)
-  finnhub            5 tools  Market news, earnings, short interest    (FINNHUB_API_KEY)
+  finnhub            4 tools  Market news, earnings, short interest    (FINNHUB_API_KEY)
   alpha-vantage      5 tools  Stock quotes, fundamentals, dividends    (ALPHA_VANTAGE_API_KEY)
 
 SETUP (Claude Code)

--- a/src/modules/finnhub/__tests__/client.test.ts
+++ b/src/modules/finnhub/__tests__/client.test.ts
@@ -100,17 +100,16 @@ describe("getCompanyNews", () => {
 });
 
 describe("createFinnhubModule", () => {
-  it("returns module with 5 tools and requires FINNHUB_API_KEY", async () => {
+  it("returns module with 4 tools and requires FINNHUB_API_KEY", async () => {
     const { createFinnhubModule } = await import("../index.js");
     const mod = createFinnhubModule("test-key");
     expect(mod.name).toBe("finnhub");
     expect(mod.requiredEnvVars).toEqual(["FINNHUB_API_KEY"]);
-    expect(mod.tools).toHaveLength(5);
+    expect(mod.tools).toHaveLength(4);
     expect(mod.tools.map((t) => t.name)).toEqual([
       "finnhub_market_news",
       "finnhub_company_news",
       "finnhub_earnings_calendar",
-      "finnhub_analyst_ratings",
       "finnhub_short_interest",
     ]);
   });

--- a/src/modules/finnhub/client.ts
+++ b/src/modules/finnhub/client.ts
@@ -138,59 +138,6 @@ export async function getEarningsCalendar(
   return result;
 }
 
-export interface AnalystRecommendation {
-  buy: number;
-  hold: number;
-  period: string;
-  sell: number;
-  strongBuy: number;
-  strongSell: number;
-  symbol: string;
-}
-
-export async function getAnalystRecommendations(
-  apiKey: string,
-  symbol: string,
-): Promise<AnalystRecommendation[]> {
-  const cacheKey = `recommendations:${symbol}`;
-  const cached = cache.get(cacheKey);
-  if (cached) return cached as AnalystRecommendation[];
-
-  const data = await httpGet<AnalystRecommendation[]>(
-    `${BASE_URL}/stock/recommendation?symbol=${encodeURIComponent(symbol)}`,
-    { headers: { "X-Finnhub-Token": apiKey } },
-  );
-
-  cache.set(cacheKey, data);
-  return data;
-}
-
-export interface PriceTarget {
-  lastUpdated: string;
-  symbol: string;
-  targetHigh: number;
-  targetLow: number;
-  targetMean: number;
-  targetMedian: number;
-}
-
-export async function getPriceTarget(
-  apiKey: string,
-  symbol: string,
-): Promise<PriceTarget> {
-  const cacheKey = `price-target:${symbol}`;
-  const cached = cache.get(cacheKey);
-  if (cached) return cached as PriceTarget;
-
-  const data = await httpGet<PriceTarget>(
-    `${BASE_URL}/stock/price-target?symbol=${encodeURIComponent(symbol)}`,
-    { headers: { "X-Finnhub-Token": apiKey } },
-  );
-
-  cache.set(cacheKey, data);
-  return data;
-}
-
 export async function getShortInterest(
   apiKey: string,
   symbol: string,

--- a/src/modules/finnhub/index.ts
+++ b/src/modules/finnhub/index.ts
@@ -5,8 +5,6 @@ import {
   getMarketNews,
   getCompanyNews,
   getEarningsCalendar,
-  getAnalystRecommendations,
-  getPriceTarget,
   getShortInterest,
 } from "./client.js";
 import { resolveTicker } from "../../shared/resolver.js";
@@ -82,29 +80,6 @@ export function createFinnhubModule(apiKey: string): ModuleDefinition {
     }, metadata),
   };
 
-  const analystRatingsTool: ToolDefinition = {
-    name: "finnhub_analyst_ratings",
-    description: "Get analyst consensus recommendations and price targets for a stock.",
-    inputSchema: z.object({
-      symbol: z.string().describe("Stock symbol (e.g. 'AAPL')"),
-    }),
-    handler: withMetadata(async (params) => {
-      const symbol = resolveTicker(params.symbol as string).ticker;
-      
-      const [recs, target] = await Promise.all([
-        getAnalystRecommendations(apiKey, symbol),
-        getPriceTarget(apiKey, symbol),
-      ]);
-
-      return successResult(JSON.stringify({
-        symbol,
-        currentConsensus: recs[0] || null,
-        priceTarget: target,
-        recommendationHistory: recs.slice(0, 4),
-      }, null, 2));
-    }, metadata),
-  };
-
   const shortInterestTool: ToolDefinition = {
     name: "finnhub_short_interest",
     description: "Get short interest and other key financial metrics for a stock.",
@@ -121,13 +96,12 @@ export function createFinnhubModule(apiKey: string): ModuleDefinition {
   return {
     name: "finnhub",
     description:
-      "Finnhub market and company news, plus earnings calendar, analyst ratings and short interest",
+      "Finnhub market and company news, plus earnings calendar and short interest",
     requiredEnvVars: ["FINNHUB_API_KEY"],
     tools: [
-      marketNewsTool, 
-      companyNewsTool, 
-      earningsCalendarTool, 
-      analystRatingsTool,
+      marketNewsTool,
+      companyNewsTool,
+      earningsCalendarTool,
       shortInterestTool,
     ],
   };


### PR DESCRIPTION
## Summary
- Removed `finnhub_analyst_ratings` tool — always returned 403 on free-tier keys
- Removed `getAnalystRecommendations()`, `getPriceTarget()`, and related types from client
- Updated tool counts: 30 → 29 in integration tests and help text
- All other finnhub tools preserved (market_news, company_news, earnings_calendar, short_interest)

Closes #60

## Test plan
- [x] `tsc --noEmit` passes
- [x] 85 tests pass
- [x] No remaining references to removed code

🤖 Generated with [Claude Code](https://claude.com/claude-code)