### PR TITLE
ci: opt into Node.js 24 for GitHub Actions runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env var to CI workflow
- Silences the deprecation warning about `actions/checkout@v4` and `actions/setup-node@v4` running on Node.js 20 internally
- Node.js 24 becomes the forced default on June 2, 2026

## Test plan

- [x] CI should pass without the deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)