### PR TITLE
feat: pre-market quotes & options ATM strike centering

### DIFF
--- a/src/modules/options/__tests__/index.test.ts
+++ b/src/modules/options/__tests__/index.test.ts
@@ -123,6 +123,81 @@ describe("options_chain", () => {
     expect(data.puts).toHaveLength(0);
   });
 
+  it("defaults to ±20% ATM strike range", async () => {
+    // underlyingPrice = 180.25, so ±20% = 144.20 – 216.30
+    // strikes 170-190 are all within range, so all 5 contracts per side should pass
+    mockFetch.mockResolvedValue(makeMockChain());
+    const mod = createOptionsModule();
+    const tool = mod.tools.find(t => t.name === "options_chain")!;
+    const result = await tool.handler({ symbol: "AAPL" });
+
+    const data = JSON.parse(result.content[0].text);
+    // All strikes 170-190 are within ±20% of 180.25
+    expect(data.calls).toHaveLength(5);
+    expect(data.puts).toHaveLength(5);
+  });
+
+  it("filters out-of-range strikes with default ±20% ATM", async () => {
+    // Create chain with wide strike range: $50 through $350 for a $180 stock
+    // ±20% of 180 = 144 – 216
+    const wideChain = makeMockChain({
+      calls: [
+        { symbol: "C50", strike: 50, lastPrice: 130, bid: 130, ask: 130, change: 0, percentChange: 0, volume: 100, openInterest: 100, impliedVolatility: 0.3, inTheMoney: true, delta: 1.0, gamma: 0, theta: 0, vega: 0 },
+        { symbol: "C100", strike: 100, lastPrice: 80, bid: 80, ask: 80, change: 0, percentChange: 0, volume: 100, openInterest: 100, impliedVolatility: 0.3, inTheMoney: true, delta: 0.95, gamma: 0.01, theta: -0.01, vega: 0.05 },
+        { symbol: "C150", strike: 150, lastPrice: 32, bid: 32, ask: 32, change: 0, percentChange: 0, volume: 100, openInterest: 100, impliedVolatility: 0.3, inTheMoney: true, delta: 0.8, gamma: 0.02, theta: -0.05, vega: 0.15 },
+        { symbol: "C180", strike: 180, lastPrice: 5, bid: 5, ask: 5, change: 0, percentChange: 0, volume: 100, openInterest: 100, impliedVolatility: 0.3, inTheMoney: true, delta: 0.55, gamma: 0.03, theta: -0.07, vega: 0.2 },
+        { symbol: "C200", strike: 200, lastPrice: 1, bid: 1, ask: 1, change: 0, percentChange: 0, volume: 100, openInterest: 100, impliedVolatility: 0.3, inTheMoney: false, delta: 0.25, gamma: 0.02, theta: -0.03, vega: 0.1 },
+        { symbol: "C250", strike: 250, lastPrice: 0.1, bid: 0.1, ask: 0.1, change: 0, percentChange: 0, volume: 100, openInterest: 100, impliedVolatility: 0.3, inTheMoney: false, delta: 0.05, gamma: 0.005, theta: -0.01, vega: 0.02 },
+        { symbol: "C350", strike: 350, lastPrice: 0.01, bid: 0.01, ask: 0.01, change: 0, percentChange: 0, volume: 100, openInterest: 100, impliedVolatility: 0.3, inTheMoney: false, delta: 0.01, gamma: 0.001, theta: -0.005, vega: 0.005 },
+      ],
+      puts: [],
+    });
+    mockFetch.mockResolvedValue(wideChain);
+
+    const mod = createOptionsModule();
+    const tool = mod.tools.find(t => t.name === "options_chain")!;
+    const result = await tool.handler({ symbol: "AAPL" });
+
+    const data = JSON.parse(result.content[0].text);
+    // Only strikes 150, 180, 200 are within 144.20 – 216.30
+    const strikes = data.calls.map((c: any) => c.strike);
+    expect(strikes).toEqual([150, 180, 200]);
+  });
+
+  it("respects explicit strike_min and strike_max", async () => {
+    mockFetch.mockResolvedValue(makeMockChain());
+    const mod = createOptionsModule();
+    const tool = mod.tools.find(t => t.name === "options_chain")!;
+    const result = await tool.handler({ symbol: "AAPL", strike_min: 175, strike_max: 185 });
+
+    const data = JSON.parse(result.content[0].text);
+    const callStrikes = data.calls.map((c: any) => c.strike);
+    expect(callStrikes).toEqual([175, 180, 185]);
+    const putStrikes = data.puts.map((p: any) => p.strike);
+    expect(putStrikes).toEqual([175, 180, 185]);
+  });
+
+  it("returns all strikes when all_strikes=true", async () => {
+    // Use wide chain that would normally be filtered
+    const wideChain = makeMockChain({
+      calls: [
+        { symbol: "C50", strike: 50, lastPrice: 130, bid: 130, ask: 130, change: 0, percentChange: 0, volume: 100, openInterest: 100, impliedVolatility: 0.3, inTheMoney: true, delta: 1.0, gamma: 0, theta: 0, vega: 0 },
+        { symbol: "C180", strike: 180, lastPrice: 5, bid: 5, ask: 5, change: 0, percentChange: 0, volume: 100, openInterest: 100, impliedVolatility: 0.3, inTheMoney: true, delta: 0.55, gamma: 0.03, theta: -0.07, vega: 0.2 },
+        { symbol: "C350", strike: 350, lastPrice: 0.01, bid: 0.01, ask: 0.01, change: 0, percentChange: 0, volume: 100, openInterest: 100, impliedVolatility: 0.3, inTheMoney: false, delta: 0.01, gamma: 0.001, theta: -0.005, vega: 0.005 },
+      ],
+      puts: [],
+    });
+    mockFetch.mockResolvedValue(wideChain);
+
+    const mod = createOptionsModule();
+    const tool = mod.tools.find(t => t.name === "options_chain")!;
+    const result = await tool.handler({ symbol: "AAPL", all_strikes: true });
+
+    const data = JSON.parse(result.content[0].text);
+    expect(data.calls).toHaveLength(3);
+    expect(data.calls.map((c: any) => c.strike)).toEqual([50, 180, 350]);
+  });
+
   it("caps limit at 200", async () => {
     // Create a chain with more than 200 contracts per side
     const bigCalls = Array.from({ length: 250 }, (_, i) => ({
@@ -135,7 +210,7 @@ describe("options_chain", () => {
 
     const mod = createOptionsModule();
     const tool = mod.tools.find(t => t.name === "options_chain")!;
-    const result = await tool.handler({ symbol: "AAPL", limit: 999 });
+    const result = await tool.handler({ symbol: "AAPL", limit: 999, all_strikes: true });
 
     const data = JSON.parse(result.content[0].text);
     expect(data.calls).toHaveLength(200);

--- a/src/modules/options/index.ts
+++ b/src/modules/options/index.ts
@@ -43,7 +43,8 @@ const chainTool: ToolDefinition = {
   description:
     "Get the full option chain (calls and puts) with calculated Greeks (Delta, Gamma, Theta, Vega). " +
     "Use options_expirations first to find valid dates. If expiration is omitted, uses nearest date. " +
-    "Response can be large — use 'limit' to cap contracts per side.",
+    "By default, returns strikes within ±20% of current price to save tokens. " +
+    "Use strike_min/strike_max for custom range, or all_strikes=true for everything.",
   inputSchema: z.object({
     symbol: symbolSchema,
     expiration: z.string().optional()
@@ -52,12 +53,39 @@ const chainTool: ToolDefinition = {
       .describe("Filter by option type (default: both)"),
     limit: z.number().optional()
       .describe("Max contracts per side (default: 50, max: 200)"),
+    strike_min: z.number().optional()
+      .describe("Minimum strike price filter (e.g. 25.0)"),
+    strike_max: z.number().optional()
+      .describe("Maximum strike price filter (e.g. 35.0)"),
+    all_strikes: z.boolean().optional()
+      .describe("Return all strikes instead of centering around ATM (default: false)"),
   }),
   handler: withMetadata(async (params) => {
     const expUnix = parseExpiration(params.expiration as string | undefined);
     const chain = await fetchOptionChain(params.symbol as string, expUnix);
 
     let { calls, puts } = chain;
+
+    // Determine strike range: explicit min/max > default ±20% ATM > all
+    const allStrikes = (params.all_strikes as boolean) ?? false;
+    const hasExplicitRange = params.strike_min != null || params.strike_max != null;
+
+    if (!allStrikes) {
+      let minStrike: number;
+      let maxStrike: number;
+
+      if (hasExplicitRange) {
+        minStrike = (params.strike_min as number) ?? 0;
+        maxStrike = (params.strike_max as number) ?? Infinity;
+      } else {
+        // Default: ±20% of underlying price
+        minStrike = chain.underlyingPrice * 0.8;
+        maxStrike = chain.underlyingPrice * 1.2;
+      }
+
+      calls = calls.filter(c => c.strike >= minStrike && c.strike <= maxStrike);
+      puts = puts.filter(c => c.strike >= minStrike && c.strike <= maxStrike);
+    }
 
     if (params.side === "call") {
       puts = [];

--- a/src/modules/tradingview/__tests__/scanner.test.ts
+++ b/src/modules/tradingview/__tests__/scanner.test.ts
@@ -3,8 +3,8 @@ import { scanStocks } from "../scanner.js";
 import { STOCK_COLUMNS, STOCK_TIMEFRAMES } from "../columns.js";
 
 describe("STOCK_COLUMNS", () => {
-  it("has 73 column IDs", () => {
-    expect(STOCK_COLUMNS).toHaveLength(73);
+  it("has 81 column IDs", () => {
+    expect(STOCK_COLUMNS).toHaveLength(81);
   });
 
   it("includes key indicators", () => {
@@ -13,6 +13,17 @@ describe("STOCK_COLUMNS", () => {
     expect(STOCK_COLUMNS).toContain("MACD.macd");
     expect(STOCK_COLUMNS).toContain("EMA200");
     expect(STOCK_COLUMNS).toContain("volume");
+  });
+
+  it("includes pre-market and post-market columns", () => {
+    expect(STOCK_COLUMNS).toContain("premarket_close");
+    expect(STOCK_COLUMNS).toContain("premarket_change");
+    expect(STOCK_COLUMNS).toContain("premarket_change_abs");
+    expect(STOCK_COLUMNS).toContain("premarket_volume");
+    expect(STOCK_COLUMNS).toContain("postmarket_close");
+    expect(STOCK_COLUMNS).toContain("postmarket_change");
+    expect(STOCK_COLUMNS).toContain("postmarket_change_abs");
+    expect(STOCK_COLUMNS).toContain("postmarket_volume");
   });
 });
 
@@ -107,6 +118,25 @@ describe("scanStocks", () => {
     expect(callBody.columns).toContain("RSI|60");
     expect(callBody.columns).toContain("name"); // metadata columns should NOT get suffix
   });
+
+  it("does not apply timeframe suffix to pre/post-market columns", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [] }),
+    });
+
+    await scanStocks({
+      timeframe: "1h",
+      columns: ["close", "premarket_close", "premarket_change", "postmarket_close", "postmarket_volume"],
+    });
+
+    const callBody = JSON.parse((fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body);
+    expect(callBody.columns).toContain("close|60");
+    expect(callBody.columns).toContain("premarket_close");
+    expect(callBody.columns).toContain("premarket_change");
+    expect(callBody.columns).toContain("postmarket_close");
+    expect(callBody.columns).toContain("postmarket_volume");
+  });
 });
 
 describe("createTradingviewModule", () => {
@@ -147,6 +177,29 @@ describe("createTradingviewModule", () => {
       // Must be valid JSON
       expect(() => JSON.parse(text)).not.toThrow();
     }
+
+    vi.restoreAllMocks();
+  });
+
+  it("quote tool requests pre-market and post-market columns", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [] }),
+    }));
+
+    const { createTradingviewModule } = await import("../index.js");
+    const mod = createTradingviewModule();
+    const quoteTool = mod.tools.find(t => t.name === "tradingview_quote")!;
+
+    await quoteTool.handler({ tickers: ["AAPL"] });
+
+    const callBody = JSON.parse((fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body);
+    expect(callBody.columns).toContain("premarket_close");
+    expect(callBody.columns).toContain("premarket_change");
+    expect(callBody.columns).toContain("premarket_volume");
+    expect(callBody.columns).toContain("postmarket_close");
+    expect(callBody.columns).toContain("postmarket_change");
+    expect(callBody.columns).toContain("postmarket_volume");
 
     vi.restoreAllMocks();
   });

--- a/src/modules/tradingview/columns.ts
+++ b/src/modules/tradingview/columns.ts
@@ -3,6 +3,8 @@ export const STOCK_COLUMNS: string[] = [
   "price_earnings_ttm", "earnings_per_share_basic_ttm", "number_of_employees",
   "sector", "description", "name", "type", "subtype", "update_mode",
   "exchange", "pricescale", "minmov", "fractional", "minmove2",
+  "premarket_close", "premarket_change", "premarket_change_abs", "premarket_volume",
+  "postmarket_close", "postmarket_change", "postmarket_change_abs", "postmarket_volume",
   "earnings_release_date", "earnings_release_next_date",
   "dividend_yield_recent", "return_on_equity_fq", "total_revenue_fq",
   "net_income_fq", "total_assets_fq", "total_debt_fq",

--- a/src/modules/tradingview/index.ts
+++ b/src/modules/tradingview/index.ts
@@ -34,7 +34,7 @@ export function createTradingviewModule(): ModuleDefinition {
       },
       {
         name: "tradingview_quote",
-        description: "Get a real-time quote for one or more stock tickers (e.g. 'AAPL' or 'NASDAQ:AAPL'). Returns price, change, volume, market cap.",
+        description: "Get a real-time quote for one or more stock tickers (e.g. 'AAPL' or 'NASDAQ:AAPL'). Returns price, change, volume, market cap, and pre-market/after-hours data when available.",
         inputSchema: z.object({
           tickers: z.array(z.string()).describe("Stock tickers, e.g. ['AAPL', 'MSFT']"),
         }),
@@ -42,7 +42,11 @@ export function createTradingviewModule(): ModuleDefinition {
           const resolvedTickers = input.tickers.map((t: string) => resolveTicker(t).full);
           const rows = await scanStocks({
             tickers: resolvedTickers,
-            columns: ["close", "change", "change_abs", "volume", "market_cap_basic", "name", "description"],
+            columns: [
+              "close", "change", "change_abs", "volume", "market_cap_basic", "name", "description",
+              "premarket_close", "premarket_change", "premarket_change_abs", "premarket_volume",
+              "postmarket_close", "postmarket_change", "postmarket_change_abs", "postmarket_volume",
+            ],
           });
           return successResult(JSON.stringify(rows, null, 2));
         }, metadata),

--- a/src/modules/tradingview/scanner.ts
+++ b/src/modules/tradingview/scanner.ts
@@ -28,6 +28,8 @@ const META_COLUMNS = new Set([
   "name", "description", "type", "subtype", "exchange",
   "sector", "update_mode", "pricescale", "minmov", "fractional",
   "minmove2", "number_of_employees", "market_cap_basic",
+  "premarket_close", "premarket_change", "premarket_change_abs", "premarket_volume",
+  "postmarket_close", "postmarket_change", "postmarket_change_abs", "postmarket_volume",
   "earnings_release_date", "earnings_release_next_date",
   "dividend_yield_recent", "return_on_equity_fq", "total_revenue_fq",
   "net_income_fq", "total_assets_fq", "total_debt_fq",


### PR DESCRIPTION
## Summary
Addresses the two HIGH priority items from #76 (LLM integration feedback):

- **Pre-market/after-hours quotes**: `tradingview_quote` now returns `premarket_close`, `premarket_change`, `premarket_change_abs`, `premarket_volume` and `postmarket_*` equivalents. These columns are also added to the full `STOCK_COLUMNS` set for `tradingview_scan`.
- **Options ATM strike centering**: `options_chain` now defaults to returning strikes within ±20% of the underlying price, dramatically reducing token usage. New params: `strike_min`, `strike_max` for custom ranges, `all_strikes: true` to disable filtering.

Closes #76 (HIGH items)

## Test plan
- [x] `npm run build` passes
- [x] All 170 tests pass (7 new tests added)
- [x] New tests: pre/post-market columns requested by quote tool, no timeframe suffix on extended-hours columns
- [x] New tests: ATM ±20% default filtering, explicit strike_min/max, all_strikes bypass, existing limit cap works with all_strikes

🤖 Generated with [Claude Code](https://claude.com/claude-code)