### PR TITLE
fix: improve tool descriptions for ticker resolution & Finnhub free tier

### DIFF
--- a/src/modules/finnhub/index.ts
+++ b/src/modules/finnhub/index.ts
@@ -84,7 +84,7 @@ export function createFinnhubModule(apiKey: string): ModuleDefinition {
 
   const analystRatingsTool: ToolDefinition = {
     name: "finnhub_analyst_ratings",
-    description: "Get analyst consensus recommendations and price targets for a stock.",
+    description: "Get analyst consensus recommendations and price targets for a stock. Note: Some tickers may return 403 errors on Finnhub free tier plans.",
     inputSchema: z.object({
       symbol: z.string().describe("Stock symbol (e.g. 'AAPL')"),
     }),

--- a/src/modules/tradingview/index.ts
+++ b/src/modules/tradingview/index.ts
@@ -34,7 +34,7 @@ export function createTradingviewModule(): ModuleDefinition {
       },
       {
         name: "tradingview_quote",
-        description: "Get a real-time quote for one or more stock tickers (e.g. 'AAPL' or 'NASDAQ:AAPL'). Returns price, change, volume, market cap, and pre-market/after-hours data when available.",
+        description: "Get a real-time quote for one or more stock tickers (e.g. 'AAPL' or 'NASDAQ:AAPL'). Returns price, change, volume, market cap, and pre-market/after-hours data when available. If a ticker returns empty results, retry with the correct exchange prefix (e.g. 'NYSE:CDE', 'AMEX:XYZ').",
         inputSchema: z.object({
           tickers: z.array(z.string()).describe("Stock tickers, e.g. ['AAPL', 'MSFT']"),
         }),
@@ -53,7 +53,7 @@ export function createTradingviewModule(): ModuleDefinition {
       },
       {
         name: "tradingview_technicals",
-        description: "Get technical indicators (RSI, MACD, moving averages, pivot points, etc.) for one or more stock tickers.",
+        description: "Get technical indicators (RSI, MACD, moving averages, pivot points, etc.) for one or more stock tickers. If a ticker returns empty results, retry with the correct exchange prefix (e.g. 'NYSE:CDE', 'AMEX:XYZ').",
         inputSchema: z.object({
           tickers: z.array(z.string()).describe("Stock tickers, e.g. ['AAPL', 'IBM']"),
           timeframe: z.string().optional().describe("Timeframe (default: 1d)"),


### PR DESCRIPTION
## Summary
- Add exchange retry hint to `tradingview_quote` and `tradingview_technicals` descriptions — guides LLM to retry with `NYSE:` or `AMEX:` prefix when a bare ticker returns empty results
- Document Finnhub free tier 403 limitation in `finnhub_analyst_ratings` description

Addresses low-priority items 5 and 6 from #76.

## Test plan
- [x] `npm run build` passes
- [x] All 170 tests pass
- [x] Description-only changes, no logic affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)