### PR TITLE
feat: add market indices tool + fix quote delay descriptions

### DIFF
--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -37,7 +37,7 @@ describe("full module wiring", () => {
       "tradingview", "tradingview-crypto", "sec-edgar", "coingecko", "options", "options-cboe",
     ]);
     const totalTools = enabled.reduce((n, m) => n + m.tools.length, 0);
-    expect(totalTools).toBe(25); // 7 + 4 + 6 + 3 + 4 + 1 (free modules only)
+    expect(totalTools).toBe(26); // 8 + 4 + 6 + 3 + 4 + 1 (free modules only)
   });
 
   it("enables all 8 modules with all API keys", () => {
@@ -49,10 +49,10 @@ describe("full module wiring", () => {
     const enabled = resolveEnabledModules(modules, env);
     expect(enabled).toHaveLength(8);
     const totalTools = enabled.reduce((n, m) => n + m.tools.length, 0);
-    expect(totalTools).toBe(39); // 7 + 4 + 6 + 3 + 4 + 1 + 9 + 5
+    expect(totalTools).toBe(40); // 8 + 4 + 6 + 3 + 4 + 1 + 9 + 5
   });
 
-  it("all 39 tool names are unique", () => {
+  it("all 40 tool names are unique", () => {
     const env = {
       FINNHUB_API_KEY: "key",
       ALPHA_VANTAGE_API_KEY: "key",
@@ -60,7 +60,7 @@ describe("full module wiring", () => {
     const modules = buildAllModules(env);
     const enabled = resolveEnabledModules(modules, env);
     const allNames = enabled.flatMap((m) => m.tools.map((t) => t.name));
-    expect(new Set(allNames).size).toBe(39);
+    expect(new Set(allNames).size).toBe(40);
   });
 
   it("respects --modules filter", () => {

--- a/src/modules/finnhub/index.ts
+++ b/src/modules/finnhub/index.ts
@@ -144,7 +144,7 @@ export function createFinnhubModule(apiKey: string): ModuleDefinition {
 
   const quoteTool: ToolDefinition = {
     name: "finnhub_quote",
-    description: "Get a real-time stock quote from Finnhub (requires API key): current price, change, percent change, day high/low, open, and previous close. Use tradingview_quote for a keyless alternative.",
+    description: "Get a real-time stock quote from Finnhub (requires API key): current price, change, percent change, day high/low, open, and previous close. Preferred over tradingview_quote during market hours for live prices. Use tradingview_quote as a keyless fallback when Finnhub is unavailable.",
     inputSchema: z.object({
       symbol: z.string().describe("Stock symbol (e.g. 'AAPL')"),
     }),

--- a/src/modules/tradingview/__tests__/scanner.test.ts
+++ b/src/modules/tradingview/__tests__/scanner.test.ts
@@ -145,7 +145,7 @@ describe("createTradingviewModule", () => {
     const mod = createTradingviewModule();
     expect(mod.name).toBe("tradingview");
     expect(mod.requiredEnvVars).toEqual([]);
-    expect(mod.tools).toHaveLength(7);
+    expect(mod.tools).toHaveLength(8);
     expect(mod.tools.map((t) => t.name)).toEqual([
       "tradingview_scan",
       "tradingview_quote",
@@ -153,6 +153,7 @@ describe("createTradingviewModule", () => {
       "tradingview_top_gainers",
       "tradingview_top_losers",
       "tradingview_top_volume",
+      "tradingview_market_indices",
       "tradingview_volume_breakout",
     ]);
   });
@@ -200,6 +201,39 @@ describe("createTradingviewModule", () => {
     expect(callBody.columns).toContain("postmarket_close");
     expect(callBody.columns).toContain("postmarket_change");
     expect(callBody.columns).toContain("postmarket_volume");
+
+    vi.restoreAllMocks();
+  });
+
+  it("market_indices tool requests VIX, SPX, NDQ, DJI", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          { s: "TVC:VIX", d: [23.5, -5.2, -1.3, 27.0, 23.1, 25.8, "VIX", "VOLATILITY S&P 500"] },
+          { s: "TVC:SPX", d: [5800, 0.5, 29, 5820, 5780, 5790, "SPX", "S&P 500"] },
+          { s: "TVC:NDQ", d: [18500, 0.8, 148, 18600, 18400, 18450, "NDQ", "NASDAQ Composite"] },
+          { s: "TVC:DJI", d: [42000, 0.3, 126, 42100, 41900, 41950, "DJI", "Dow Jones Industrial Average"] },
+        ],
+      }),
+    }));
+
+    const { createTradingviewModule } = await import("../index.js");
+    const mod = createTradingviewModule();
+    const tool = mod.tools.find(t => t.name === "tradingview_market_indices")!;
+
+    const result = await tool.handler({});
+
+    const callBody = JSON.parse((fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body);
+    expect(callBody.symbols.tickers).toEqual(["TVC:VIX", "TVC:SPX", "TVC:NDQ", "TVC:DJI"]);
+    expect(callBody.columns).toContain("close");
+    expect(callBody.columns).toContain("change");
+    expect(callBody.columns).toContain("name");
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed).toHaveLength(4);
+    expect(parsed[0].symbol).toBe("TVC:VIX");
+    expect(parsed[0].data.close).toBe(23.5);
 
     vi.restoreAllMocks();
   });

--- a/src/modules/tradingview/index.ts
+++ b/src/modules/tradingview/index.ts
@@ -34,7 +34,7 @@ export function createTradingviewModule(): ModuleDefinition {
       },
       {
         name: "tradingview_quote",
-        description: "Get a real-time quote for one or more stock tickers (e.g. 'AAPL' or 'NASDAQ:AAPL'). Returns price, change, volume, market cap, and pre-market/after-hours data when available. If a ticker returns empty results, retry with the correct exchange prefix (e.g. 'NYSE:CDE', 'AMEX:XYZ').",
+        description: "Get a 15-minute delayed quote for one or more stock tickers (e.g. 'AAPL' or 'NASDAQ:AAPL'). Returns price, change, volume, market cap, and pre-market/after-hours data when available. Data is delayed ~15 minutes during market hours — use finnhub_quote for real-time prices if available. If a ticker returns empty results, retry with the correct exchange prefix (e.g. 'NYSE:CDE', 'AMEX:XYZ').",
         inputSchema: z.object({
           tickers: z.array(z.string()).describe("Stock tickers, e.g. ['AAPL', 'MSFT']"),
         }),
@@ -135,6 +135,20 @@ export function createTradingviewModule(): ModuleDefinition {
             filters,
             limit: input.limit ?? 20,
           });
+          return successResult(JSON.stringify(rows, null, 2));
+        }, metadata),
+      },
+      {
+        name: "tradingview_market_indices",
+        description: "Get real-time values for major market indices: VIX (volatility), S&P 500, NASDAQ Composite, and Dow Jones. Essential for gauging broad market conditions, risk sentiment, and options pricing context.",
+        inputSchema: z.object({}),
+        handler: withMetadata(async () => {
+          const tickers = ["TVC:VIX", "TVC:SPX", "TVC:NDQ", "TVC:DJI"];
+          const columns = [
+            "close", "change", "change_abs", "high", "low", "open",
+            "name", "description",
+          ];
+          const rows = await scanStocks({ tickers, columns });
           return successResult(JSON.stringify(rows, null, 2));
         }, metadata),
       },


### PR DESCRIPTION
## Summary
- Add `tradingview_market_indices` tool — returns VIX, S&P 500, NASDAQ, and Dow Jones in a single keyless scanner call (closes benchmark gaps #1 and #3)
- Fix `tradingview_quote` description: was misleadingly labeled "real-time", now clearly states 15-min delay and directs LLMs to `finnhub_quote` for live prices
- Fix `finnhub_quote` description: now states it is preferred during market hours

## Test plan
- [x] New test: `market_indices tool requests VIX, SPX, NDQ, DJI` — verifies tickers, columns, and response mapping
- [x] Integration test counts updated (39→40 tools)
- [x] All 176 tests pass
- [x] Lint + build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)