### PR TITLE
chore: release v1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stock-scanner-mcp",
-  "version": "1.2.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stock-scanner-mcp",
-      "version": "1.2.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stock-scanner-mcp",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "MCP server providing Claude Code with real-time stock and crypto market data, SEC filings, insider trades, and technical analysis",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump version to v1.4.0
- Includes: `tradingview_market_indices` tool (VIX, S&P 500, NASDAQ, Dow) + quote delay description fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)