### PR TITLE
chore: release v1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stock-scanner-mcp",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "MCP server providing Claude Code with real-time stock and crypto market data, SEC filings, insider trades, and technical analysis",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump version to v1.5.0 (minor release)
- Includes: market indices global endpoint fix, /release-npm slash command

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (177 tests)
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)