### PR TITLE
fix: Yahoo Finance rate limit cooldown

### DIFF
--- a/src/modules/options/yahoo-session.ts
+++ b/src/modules/options/yahoo-session.ts
@@ -14,6 +14,7 @@ const COOKIE_URL = "https://fc.yahoo.com/curveball";
 const CRUMB_URL = "https://query1.finance.yahoo.com/v1/test/getcrumb";
 const SESSION_TTL = 30 * 60 * 1000; // 30 minutes
 const TIMEOUT_MS = 10_000;
+const RATE_LIMIT_COOLDOWN = 5 * 60 * 1000; // 5 minutes lockout on 429
 
 export const YAHOO_USER_AGENT =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
@@ -26,8 +27,16 @@ interface YahooSession {
 
 let session: YahooSession | null = null;
 let sessionPromise: Promise<YahooSession> | null = null;
+let lastRateLimitTime = 0;
 
 async function createSession(): Promise<YahooSession> {
+  // Prevent retries during cooldown period
+  const now = Date.now();
+  if (now - lastRateLimitTime < RATE_LIMIT_COOLDOWN) {
+    const remaining = Math.ceil((RATE_LIMIT_COOLDOWN - (now - lastRateLimitTime)) / 1000);
+    throw new Error(`Yahoo Finance rate limit cooldown active. Please wait ${remaining}s.`);
+  }
+
   const controller1 = new AbortController();
   const timer1 = setTimeout(() => controller1.abort(), TIMEOUT_MS);
 
@@ -42,12 +51,22 @@ async function createSession(): Promise<YahooSession> {
       redirect: "manual",
       signal: controller1.signal,
     });
+    
     // Extract A3 cookie from Set-Cookie header
-    const setCookie = (cookieResp.headers as any).getSetCookie?.()
-      ?? [cookieResp.headers.get("set-cookie") ?? ""];
+    const headers = cookieResp.headers;
+    let setCookie: string[] = [];
+    if (headers) {
+      if (typeof (headers as any).getSetCookie === "function") {
+        setCookie = (headers as any).getSetCookie();
+      } else if (typeof headers.get === "function") {
+        const val = headers.get("set-cookie");
+        if (val) setCookie = [val];
+      }
+    }
+
     const a3 = setCookie
-      .map((c: string) => c.split(";")[0])
-      .find((c: string) => c.startsWith("A3="));
+      .map(c => c.split(";")[0])
+      .find(c => c.startsWith("A3="));
     if (!a3) {
       throw new Error("Yahoo session: failed to obtain A3 cookie");
     }
@@ -71,11 +90,18 @@ async function createSession(): Promise<YahooSession> {
       },
       signal: controller2.signal,
     });
+
+    if (crumbResp.status === 429) {
+      lastRateLimitTime = Date.now();
+      throw new Error("Yahoo session: IP rate limited (429). Cooling down for 5 minutes.");
+    }
+
     if (!crumbResp.ok) {
       throw new Error(`Yahoo session: crumb request failed (${crumbResp.status})`);
     }
     crumb = await crumbResp.text();
     if (!crumb || crumb.includes("Too Many") || crumb.includes("error")) {
+      if (crumb.includes("Too Many")) lastRateLimitTime = Date.now();
       throw new Error(`Yahoo session: invalid crumb response: ${crumb.slice(0, 100)}`);
     }
   } finally {


### PR DESCRIPTION
Added a 5-minute lockout period when a 429 Too Many Requests is detected from Yahoo Finance to prevent further IP blacklisting. Removed debug logs.