### PR TITLE
feat: OTC filtering, sector performance, implied move (P1)

### DIFF
--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -37,7 +37,7 @@ describe("full module wiring", () => {
       "tradingview", "tradingview-crypto", "sec-edgar", "coingecko", "options", "options-cboe",
     ]);
     const totalTools = enabled.reduce((n, m) => n + m.tools.length, 0);
-    expect(totalTools).toBe(26); // 8 + 4 + 6 + 3 + 4 + 1 (free modules only)
+    expect(totalTools).toBe(28); // 9 + 4 + 6 + 3 + 5 + 1 (free modules only)
   });
 
   it("enables all 8 modules with all API keys", () => {
@@ -49,10 +49,10 @@ describe("full module wiring", () => {
     const enabled = resolveEnabledModules(modules, env);
     expect(enabled).toHaveLength(8);
     const totalTools = enabled.reduce((n, m) => n + m.tools.length, 0);
-    expect(totalTools).toBe(40); // 8 + 4 + 6 + 3 + 4 + 1 + 9 + 5
+    expect(totalTools).toBe(42); // 9 + 4 + 6 + 3 + 5 + 1 + 9 + 5
   });
 
-  it("all 40 tool names are unique", () => {
+  it("all 42 tool names are unique", () => {
     const env = {
       FINNHUB_API_KEY: "key",
       ALPHA_VANTAGE_API_KEY: "key",
@@ -60,7 +60,7 @@ describe("full module wiring", () => {
     const modules = buildAllModules(env);
     const enabled = resolveEnabledModules(modules, env);
     const allNames = enabled.flatMap((m) => m.tools.map((t) => t.name));
-    expect(new Set(allNames).size).toBe(40);
+    expect(new Set(allNames).size).toBe(42);
   });
 
   it("respects --modules filter", () => {

--- a/src/modules/options/__tests__/index.test.ts
+++ b/src/modules/options/__tests__/index.test.ts
@@ -37,16 +37,17 @@ function makeMockChain(overrides: Partial<OptionChain> = {}): OptionChain {
 }
 
 describe("createOptionsModule", () => {
-  it("has 4 tools and no required env vars", () => {
+  it("has 5 tools and no required env vars", () => {
     const mod = createOptionsModule();
     expect(mod.name).toBe("options");
     expect(mod.requiredEnvVars).toEqual([]);
-    expect(mod.tools).toHaveLength(4);
+    expect(mod.tools).toHaveLength(5);
     expect(mod.tools.map(t => t.name)).toEqual([
       "options_expirations",
       "options_chain",
       "options_unusual_activity",
       "options_max_pain",
+      "options_implied_move",
     ]);
   });
 });
@@ -318,5 +319,62 @@ describe("options_max_pain", () => {
     const data = JSON.parse(result.content[0].text);
     expect(data.error).toBe(true);
     expect(data.message).toContain("No options data found");
+  });
+});
+
+describe("options_implied_move", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it("calculates implied move from ATM straddle", async () => {
+    // underlyingPrice = 180.25
+    // ATM call (strike 180) lastPrice = 5.5
+    // ATM put (strike 180) lastPrice = 4.2
+    // straddle = 9.7, implied move = 9.7/180.25 = 5.38%
+    mockFetch.mockResolvedValue(makeMockChain());
+    const mod = createOptionsModule();
+    const tool = mod.tools.find(t => t.name === "options_implied_move")!;
+    const result = await tool.handler({ symbol: "AAPL" });
+
+    expect(result.isError).toBeUndefined();
+    const data = JSON.parse(result.content[0].text);
+    expect(data.symbol).toBe("AAPL");
+    expect(data.underlyingPrice).toBe(180.25);
+    expect(data.atmCallStrike).toBe(180);
+    expect(data.atmPutStrike).toBe(180);
+    expect(data.atmCallPrice).toBe(5.5);
+    expect(data.atmPutPrice).toBe(4.2);
+    expect(data.straddlePrice).toBe(9.7);
+    expect(data.impliedMove).toBeCloseTo(5.38, 1);
+    expect(data.impliedMoveAbsolute).toBe(9.7);
+    expect(data.expectedRange.low).toBeCloseTo(170.55, 1);
+    expect(data.expectedRange.high).toBeCloseTo(189.95, 1);
+    expect(data.impliedVolatility).toBeGreaterThan(0);
+    expect(data.expiration).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("finds closest ATM strike when no exact match", async () => {
+    // underlyingPrice = 182 — between 180 and 185 strikes
+    const chain = makeMockChain({ underlyingPrice: 182 });
+    mockFetch.mockResolvedValue(chain);
+    const mod = createOptionsModule();
+    const tool = mod.tools.find(t => t.name === "options_implied_move")!;
+    const result = await tool.handler({ symbol: "AAPL" });
+
+    const data = JSON.parse(result.content[0].text);
+    // 180 is closer to 182 than 185
+    expect(data.atmCallStrike).toBe(180);
+    expect(data.atmPutStrike).toBe(180);
+  });
+
+  it("returns error when no options data available", async () => {
+    mockFetch.mockResolvedValue(makeMockChain({ calls: [], puts: [] }));
+    const mod = createOptionsModule();
+    const tool = mod.tools.find(t => t.name === "options_implied_move")!;
+    const result = await tool.handler({ symbol: "AAPL" });
+
+    const data = JSON.parse(result.content[0].text);
+    expect(data.error).toContain("Insufficient");
   });
 });

--- a/src/modules/options/index.ts
+++ b/src/modules/options/index.ts
@@ -180,11 +180,78 @@ const maxPainTool: ToolDefinition = {
   }, metadata),
 };
 
+const impliedMoveTool: ToolDefinition = {
+  name: "options_implied_move",
+  description:
+    "Calculate the expected move implied by options pricing (ATM straddle). " +
+    "Essential for earnings plays — shows how much the market expects the stock to move. " +
+    "Compare implied vs historical moves to assess if premium is cheap or expensive.",
+  inputSchema: z.object({
+    symbol: symbolSchema,
+    expiration: z.string().optional()
+      .describe("Expiration date as YYYY-MM-DD. If omitted, uses nearest."),
+  }),
+  handler: withMetadata(async (params) => {
+    const expUnix = parseExpiration(params.expiration as string | undefined);
+    const chain = await fetchOptionChain(params.symbol as string, expUnix);
+    const price = chain.underlyingPrice;
+    const expDate = chain.expirationDates[0]
+      ? new Date(chain.expirationDates[0] * 1000).toISOString().split("T")[0]
+      : "unknown";
+
+    // Find ATM call and put (closest strikes to underlying price)
+    const atmCall = chain.calls.reduce((best, c) =>
+      Math.abs(c.strike - price) < Math.abs(best.strike - price) ? c : best,
+      chain.calls[0],
+    );
+    const atmPut = chain.puts.reduce((best, p) =>
+      Math.abs(p.strike - price) < Math.abs(best.strike - price) ? p : best,
+      chain.puts[0],
+    );
+
+    if (!atmCall || !atmPut) {
+      return successResult(JSON.stringify({
+        symbol: chain.underlyingSymbol,
+        underlyingPrice: price,
+        error: "Insufficient options data to calculate implied move",
+      }, null, 2));
+    }
+
+    // ATM straddle price = ATM call last + ATM put last
+    const callPrice = atmCall.lastPrice || ((atmCall.bid + atmCall.ask) / 2) || 0;
+    const putPrice = atmPut.lastPrice || ((atmPut.bid + atmPut.ask) / 2) || 0;
+    const straddlePrice = callPrice + putPrice;
+    const impliedMoveAbs = straddlePrice;
+    const impliedMovePct = price > 0 ? (straddlePrice / price) * 100 : 0;
+
+    // Average IV from ATM options
+    const avgIv = ((atmCall.impliedVolatility || 0) + (atmPut.impliedVolatility || 0)) / 2;
+
+    return successResult(JSON.stringify({
+      symbol: chain.underlyingSymbol,
+      underlyingPrice: price,
+      expiration: expDate,
+      atmCallStrike: atmCall.strike,
+      atmCallPrice: callPrice,
+      atmPutStrike: atmPut.strike,
+      atmPutPrice: putPrice,
+      straddlePrice,
+      impliedMove: Math.round(impliedMovePct * 100) / 100,
+      impliedMoveAbsolute: Math.round(impliedMoveAbs * 100) / 100,
+      impliedVolatility: Math.round(avgIv * 10000) / 100,
+      expectedRange: {
+        low: Math.round((price - impliedMoveAbs) * 100) / 100,
+        high: Math.round((price + impliedMoveAbs) * 100) / 100,
+      },
+    }, null, 2));
+  }, metadata),
+};
+
 export function createOptionsModule(): ModuleDefinition {
   return {
     name: "options",
-    description: "Stock options chains, Greeks, unusual activity, and max pain from Yahoo Finance (no API key required)",
+    description: "Stock options chains, Greeks, unusual activity, implied move, and max pain from Yahoo Finance (no API key required)",
     requiredEnvVars: [],
-    tools: [expirationsTool, chainTool, unusualActivityTool, maxPainTool],
+    tools: [expirationsTool, chainTool, unusualActivityTool, maxPainTool, impliedMoveTool],
   };
 }

--- a/src/modules/tradingview/__tests__/scanner.test.ts
+++ b/src/modules/tradingview/__tests__/scanner.test.ts
@@ -155,12 +155,12 @@ describe("scanStocks", () => {
 });
 
 describe("createTradingviewModule", () => {
-  it("returns module with 6 tools and no required env vars", async () => {
+  it("returns module with 9 tools and no required env vars", async () => {
     const { createTradingviewModule } = await import("../index.js");
     const mod = createTradingviewModule();
     expect(mod.name).toBe("tradingview");
     expect(mod.requiredEnvVars).toEqual([]);
-    expect(mod.tools).toHaveLength(8);
+    expect(mod.tools).toHaveLength(9);
     expect(mod.tools.map((t) => t.name)).toEqual([
       "tradingview_scan",
       "tradingview_quote",
@@ -169,6 +169,7 @@ describe("createTradingviewModule", () => {
       "tradingview_top_losers",
       "tradingview_top_volume",
       "tradingview_market_indices",
+      "tradingview_sector_performance",
       "tradingview_volume_breakout",
     ]);
   });

--- a/src/modules/tradingview/index.ts
+++ b/src/modules/tradingview/index.ts
@@ -77,15 +77,18 @@ export function createTradingviewModule(): ModuleDefinition {
       },
       {
         name: "tradingview_top_gainers",
-        description: "Get today's top gaining stocks by percentage change on a given exchange. Defaults to major US exchanges (NYSE, NASDAQ, AMEX) with market cap > $100M.",
+        description: "Get today's top gaining stocks by percentage change on a given exchange. Defaults to major US exchanges (NYSE, NASDAQ, AMEX) with market cap > $100M. OTC penny stocks excluded by default.",
         inputSchema: z.object({
           exchange: z.string().optional().describe("Exchange (default: all US)"),
+          include_otc: z.boolean().optional().describe("Whether to include OTC penny stocks (default: false)"),
           limit: z.number().optional().describe("Max results (default 20)"),
         }),
         handler: withMetadata(async (input) => {
-          const filters = [
-            { left: "market_cap_basic", operation: "greater", right: 100_000_000 },
-          ];
+          const filters = [];
+          if (!input.include_otc) {
+            filters.push({ left: "market_cap_basic", operation: "greater", right: 100_000_000 });
+            filters.push({ left: "volume", operation: "greater", right: 100_000 });
+          }
           const rows = await scanStocks({
             exchange: input.exchange,
             columns: ["close", "change", "change_abs", "volume", "name", "description", "market_cap_basic"],
@@ -97,15 +100,18 @@ export function createTradingviewModule(): ModuleDefinition {
       },
       {
         name: "tradingview_top_losers",
-        description: "Get today's top losing stocks by percentage change on a given exchange. Defaults to major US exchanges (NYSE, NASDAQ, AMEX) with market cap > $100M.",
+        description: "Get today's top losing stocks by percentage change on a given exchange. Defaults to major US exchanges (NYSE, NASDAQ, AMEX) with market cap > $100M. OTC penny stocks excluded by default.",
         inputSchema: z.object({
           exchange: z.string().optional().describe("Exchange (default: all US)"),
+          include_otc: z.boolean().optional().describe("Whether to include OTC penny stocks (default: false)"),
           limit: z.number().optional().describe("Max results (default 20)"),
         }),
         handler: withMetadata(async (input) => {
-          const filters = [
-            { left: "market_cap_basic", operation: "greater", right: 100_000_000 },
-          ];
+          const filters = [];
+          if (!input.include_otc) {
+            filters.push({ left: "market_cap_basic", operation: "greater", right: 100_000_000 });
+            filters.push({ left: "volume", operation: "greater", right: 100_000 });
+          }
           const rows = await scanStocks({
             exchange: input.exchange,
             columns: ["close", "change", "change_abs", "volume", "name", "description", "market_cap_basic"],
@@ -149,6 +155,25 @@ export function createTradingviewModule(): ModuleDefinition {
             "name", "description",
           ];
           const rows = await scanStocks({ tickers, columns, market: "global" });
+          return successResult(JSON.stringify(rows, null, 2));
+        }, metadata),
+      },
+      {
+        name: "tradingview_sector_performance",
+        description: "Get performance of S&P 500 sector ETFs (XLK, XLF, XLE, XLV, XLI, XLP, XLU, XLY, XLC, XLRE, XLB). Shows which sectors are leading or lagging today. Essential for sector rotation analysis.",
+        inputSchema: z.object({}),
+        handler: withMetadata(async () => {
+          const sectorEtfs = [
+            "AMEX:XLK", "AMEX:XLF", "AMEX:XLE", "AMEX:XLV", "AMEX:XLI",
+            "AMEX:XLP", "AMEX:XLU", "AMEX:XLY", "AMEX:XLC", "AMEX:XLRE", "AMEX:XLB",
+          ];
+          const rows = await scanStocks({
+            tickers: sectorEtfs,
+            columns: [
+              "close", "change", "change_abs", "volume", "name", "description",
+              "Perf.W", "Perf.1M", "Perf.3M", "Perf.YTD",
+            ],
+          });
           return successResult(JSON.stringify(rows, null, 2));
         }, metadata),
       },


### PR DESCRIPTION
## Summary
- **#90:** Add `include_otc` param to `top_gainers` and `top_losers` — OTC penny stocks filtered by default (market cap > $100M, volume > 100K)
- **#40:** New `tradingview_sector_performance` tool — tracks 11 S&P SPDR sector ETFs with daily/weekly/monthly/YTD performance
- **#91:** New `options_implied_move` tool — calculates expected move from ATM straddle pricing for earnings plays

## New Tools
| Tool | Description |
|------|-------------|
| `tradingview_sector_performance` | S&P sector ETF performance (XLK, XLF, XLE, etc.) |
| `options_implied_move` | ATM straddle implied move calculation |

## Test plan
- [x] 181 tests pass (up from 178)
- [x] `npm run lint` passes
- [x] `npm run build` passes
- [ ] Live test `tradingview_sector_performance` 
- [ ] Live test `options_implied_move`
- [ ] Verify `top_gainers`/`top_losers` no longer return OTC stocks

Closes #90, closes #40, closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)