### PR TITLE
chore: release v1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stock-scanner-mcp",
-  "version": "1.4.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stock-scanner-mcp",
-      "version": "1.4.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stock-scanner-mcp",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "MCP server providing Claude Code with real-time stock and crypto market data, SEC filings, insider trades, and technical analysis",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump version to v1.6.0 (minor)
- Includes all changes since v1.5.0: OTC filtering, sector performance, implied move, CBOE put/call ratio fix

## Quality gates
- ✅ lint (tsc --noEmit)
- ✅ 181 tests passing
- ✅ build (tsup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)