### PR TITLE
docs: update standards with PR #98 learnings + add /learn-from-pr command

### DIFF
--- a/.claude/commands/learn-from-pr.md
+++ b/.claude/commands/learn-from-pr.md
@@ -1,0 +1,42 @@
+Extract lessons from a PR review and improve project standards. Argument: $ARGUMENTS (PR number or URL, or "last" for most recent reviewed PR).
+
+## Steps
+
+1. **Gather PR review findings**
+   - If a PR number/URL is provided, fetch the review comments: `gh pr view <number> --comments`
+   - If "last" or no argument, check the current conversation for review findings
+   - If no findings anywhere, ask the user to provide the PR or paste findings
+
+2. **Categorize each finding**
+   For every issue raised in the review, classify it:
+   - **Pattern violation** — existing standard was broken (→ strengthen the standard or add enforcement)
+   - **Missing standard** — no rule existed to prevent this (→ add a new rule)
+   - **Missing checklist item** — a pre-merge check would have caught it (→ add to checklist)
+   - **Test gap** — a category of test was missing (→ add to testing standards)
+   - **Informational** — good practice, no action needed
+
+3. **Read current standards files**
+   - Read `docs/development-standards.md` — architecture, patterns, naming, testing, error handling
+   - Read `docs/pre-flight-checklist.md` — pre-flight steps
+   - Read `CLAUDE.md` — project overview and key rules
+
+4. **Draft proposed changes**
+   For each non-informational finding, propose a specific edit:
+   - Identify the exact section in the target file
+   - Write the new/updated text
+   - Explain why (link to the PR finding)
+   Present ALL proposed changes to the user for approval before editing.
+
+5. **Apply approved changes**
+   - Edit the target files with the approved changes
+   - Keep existing formatting and style consistent
+   - Do NOT remove or weaken existing rules — only add or strengthen
+
+6. **Verify consistency**
+   - Check that CLAUDE.md summary rules still match the detailed standards
+   - Check that no two rules contradict each other
+   - If CLAUDE.md needs updating to reflect new rules, update it
+
+7. **Report**
+   - Summarize what was added/changed
+   - List any findings that were skipped and why

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,14 +2,10 @@
 
 ## Status
 
-**Phase:** Design & planning complete. Implementation not started.
+**Version:** 1.6.0 — Published on npm as `stock-scanner-mcp`
+**Modules:** 8 implemented (43 tools total)
 
-- Brainstorm: `docs/2026-03-12-brainstorm-session.md`
-- Architecture: `docs/architecture.md`
-- Implementation plan: `docs/plans/2026-03-12-stock-scanner-plugin.md`
-- Task files (15): `docs/plans/tasks/task-01-scaffolding.md` through `task-15-readme.md`
-
-**To start implementation:** Use `superpowers:executing-plans` or `superpowers:subagent-driven-development` skill with the plan.
+Planning docs (historical): `docs/architecture.md`, `docs/plans/`
 
 ## Project Overview
 
@@ -21,14 +17,12 @@ A modular, open-source MCP (Model Context Protocol) server that provides Claude 
 - **Runtime:** Node.js
 - **Protocol:** MCP over stdio (JSON-RPC)
 - **SDK:** `@modelcontextprotocol/sdk`
-- **Build:** tsc (TypeScript compiler)
+- **Build:** tsup (bundles to ESM)
 - **Test:** vitest
 - **Schema:** zod
 - **Distribution:** npm (`npx stock-scanner-mcp`)
 
-## Planned Project Structure
-
-> **Note:** Not yet scaffolded. See `docs/plans/tasks/task-01-scaffolding.md` for setup.
+## Project Structure
 
 ```
 stock-scanner-mcp/
@@ -48,7 +42,9 @@ stock-scanner-mcp/
 │   └── shared/
 │       ├── http.ts           # HTTP client with timeouts
 │       ├── cache.ts          # In-memory TTL cache
-│       └── types.ts          # Shared types
+│       ├── types.ts          # Shared types + result builders
+│       ├── resolver.ts       # Ticker resolution (AAPL → NASDAQ:AAPL)
+│       └── utils.ts          # withMetadata() wrapper
 ├── package.json
 ├── tsconfig.json
 └── vitest.config.ts
@@ -56,14 +52,15 @@ stock-scanner-mcp/
 
 ## Key Commands
 
-> **Note:** These commands will work after task-01 (scaffolding) is complete.
-
 ```bash
-npm install
-npm run build
-node dist/index.js
-node dist/index.js --modules tradingview,finnhub
-npm test
+npm install           # Install dependencies
+npm run build         # Build with tsup → dist/
+npm run dev           # Watch mode (rebuild on save)
+npm test              # Run all tests (vitest)
+npm run test:watch    # Watch mode tests
+npm run lint          # Type-check (tsc --noEmit)
+node dist/index.js    # Run MCP server
+node dist/index.js --modules tradingview,finnhub  # Run specific modules
 ```
 
 ## Configuration
@@ -127,7 +124,10 @@ Read it before writing any code. Key rules summarized below:
 - All URL parameters use `encodeURIComponent()`; API keys passed via headers, never query params
 - Response payloads truncated to control token usage
 - In-memory TTL cache (`shared/cache.ts`) for all external API calls
-- Tool descriptions must be LLM-readable, disambiguated from similar tools, and honest about limitations
+- Tool descriptions must be LLM-readable, disambiguated from similar tools, honest about limitations, and include value scales for ratings/scores
+- All tools in a module MUST use the same response shape (standard: `JSON.stringify(rows, null, 2)`)
+- Tools returning stock data MUST include both `name` and `description` metadata columns
+- Every new tool handler MUST have a dedicated test (columns, input resolution, response shape, edge cases)
 - Schema defaults declared via `.default()` in zod (not manual fallbacks) so LLMs see them
 - All response types must have TypeScript interfaces (no `any` in new code)
 - Imports must use `.js` extension (ESM requirement)

--- a/docs/development-standards.md
+++ b/docs/development-standards.md
@@ -144,6 +144,8 @@ Tool descriptions are consumed by LLMs to decide which tool to call. They MUST b
 3. **Specific about defaults** — mention default values for optional params
 4. **Honest about limitations** — mention API key requirements, data delays, rate limits
 
+5. **Scale/range documented** — if a field returns a rating, score, or non-obvious numeric range, state the scale (e.g., "recommendation rating from -1 (strong sell) to +1 (strong buy)")
+
 **Good:**
 ```
 "Get a real-time stock quote from Finnhub (requires API key): current price, change,
@@ -151,9 +153,17 @@ percent change, day high/low, open, and previous close. Use tradingview_quote fo
 keyless alternative."
 ```
 
+```
+"Returns analyst recommendation rating (-1 sell to +1 buy) and RSI (0-100)."
+```
+
 **Bad:**
 ```
 "Get stock quote."
+```
+
+```
+"Returns analyst recommendation."  // What scale? What do values mean?
 ```
 
 ### Schema Defaults
@@ -198,6 +208,16 @@ All tool handlers MUST be wrapped with `withMetadata()`. It:
 
 **Rule:** Tool handlers MUST NEVER throw unhandled exceptions to the MCP client.
 
+### Response Shape Consistency
+
+All tool handlers within a module MUST return the same response shape. The standard shape is `JSON.stringify(rows, null, 2)` where `rows` is the `ScanRow[]` array from `scanStocks()` or equivalent. Do NOT invent custom wrapper objects (e.g. `{ tickers, metrics, data }`) — this forces LLMs to handle multiple response formats from the same module.
+
+If a tool needs a genuinely different shape, document it in the tool description and add a test verifying the shape.
+
+### Metadata Columns
+
+When a tool returns data about stocks/instruments, ALWAYS include both `name` (short identifier) and `description` (full company name) columns. Users and LLMs need the human-readable name for context. Check existing tools in the same module for the standard set of metadata columns and match them.
+
 ---
 
 ## 6. HTTP Client
@@ -232,6 +252,12 @@ All HTTP calls MUST go through `shared/http.ts`. Direct `fetch()` calls are proh
 - **Every new client function** MUST have at least one unit test
 - **Every modified function** MUST have its tests updated if behavior changed
 - **Every module** MUST have a test verifying tool count and tool names
+- **Every new tool handler** MUST have a dedicated test that verifies:
+  1. Correct columns/parameters sent to the underlying API call
+  2. Input resolution (e.g., ticker resolution from simple → exchange-qualified)
+  3. Response structure matches expected shape
+- **Schema validation edge cases** MUST be tested when zod constraints are non-trivial (e.g., `.min(2).max(5)` on an array — test both below-min and above-max inputs)
+- **Partial data** — test behavior when some items return data and others don't (e.g., 1 of 3 tickers not found)
 - **Integration tests** (`src/__tests__/integration.test.ts`) MUST be updated when tool counts change
 - **PRs without test coverage for changed code will be rejected**
 
@@ -332,7 +358,20 @@ npm run test:watch    # Watch mode during development
 
 ---
 
-## 12. Code Quality Gates
+## 12. Adding a New Tool to an Existing Module — Checklist
+
+1. Add the tool definition in the module's `index.ts` (follow naming: `{module}_{action}`)
+2. Include both `name` and `description` metadata columns if tool returns stock/instrument data
+3. Use the same response shape as other tools in the module (usually `JSON.stringify(rows, null, 2)`)
+4. Write an LLM-friendly tool description — include value scales, limitations, and disambiguation from similar tools
+5. Add a **dedicated handler test** in `__tests__/scanner.test.ts` (or equivalent) verifying columns, input resolution, and response shape
+6. Add **edge case tests** for any non-trivial schema constraints (min/max array length, etc.)
+7. Update tool count assertions in the module test (`mod.tools.toHaveLength(N)`) and tool name list
+8. Update integration test tool counts in `src/__tests__/integration.test.ts`
+
+---
+
+## 13. Code Quality Gates
 
 Before any PR is merged:
 


### PR DESCRIPTION
## Summary
- **New `/learn-from-pr` command** — extracts lessons from PR reviews and applies them to project standards
- **Development standards updated** with 5 new rules learned from PR #98 review:
  - Response shape consistency within modules
  - Mandatory `name` + `description` metadata columns
  - Value scale documentation in tool descriptions
  - Per-handler dedicated test requirements
  - Schema edge case test requirements
- **New §12 checklist**: "Adding a New Tool to an Existing Module" (8-step)
- **CLAUDE.md refreshed**: status reflects v1.6.0, build tool corrected to tsup, structure shows actual shared utilities, all commands documented

## Test plan
- [ ] Verify `docs/development-standards.md` section numbering is sequential (§1–§13)
- [ ] Verify `CLAUDE.md` mandatory rules align with detailed standards
- [ ] Verify `/learn-from-pr` command is discoverable via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)