### PR TITLE
chore: release v1.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stock-scanner-mcp",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "MCP server providing Claude Code with real-time stock and crypto market data, SEC filings, insider trades, and technical analysis",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump version to 1.7.0

## Changes since v1.6.0
- feat: add `tradingview_compare_stocks` tool for side-by-side analysis (#98)
- docs: update development standards with PR review learnings (#99)
- docs: add `/learn-from-pr` command
- docs: refresh CLAUDE.md to reflect v1.6.0+ status