### PR TITLE
fix: filter FRED calendar to future dates only

### DIFF
--- a/src/modules/fred/__tests__/client.test.ts
+++ b/src/modules/fred/__tests__/client.test.ts
@@ -39,7 +39,7 @@ describe("getEconomicCalendar", () => {
     expect(result[2].release_name).toBe("Employment Situation");
   });
 
-  it("passes API key as query parameter", async () => {
+  it("passes API key and realtime_start as query parameters", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       json: async () => ({ release_dates: [] }),
@@ -51,6 +51,9 @@ describe("getEconomicCalendar", () => {
     expect(calledUrl).toContain("api_key=my-fred-key");
     expect(calledUrl).toContain("include_release_dates_with_no_data=true");
     expect(calledUrl).toContain("file_type=json");
+    // Should filter to today and future dates only
+    const today = new Date().toISOString().slice(0, 10);
+    expect(calledUrl).toContain(`realtime_start=${today}`);
   });
 
   it("returns empty array when no upcoming releases", async () => {

--- a/src/modules/fred/client.ts
+++ b/src/modules/fred/client.ts
@@ -126,7 +126,8 @@ export async function getEconomicCalendar(
   apiKey: string,
   limit = 60,
 ): Promise<FredReleaseDate[]> {
-  const cacheKey = `calendar:${limit}`;
+  const today = new Date().toISOString().slice(0, 10);
+  const cacheKey = `calendar:${today}:${limit}`;
   const cached = cache.get(cacheKey);
   if (cached) return cached as FredReleaseDate[];
 
@@ -136,6 +137,7 @@ export async function getEconomicCalendar(
     `${BASE_URL}/releases/dates` +
     `?api_key=${encodeURIComponent(apiKey)}` +
     `&file_type=json` +
+    `&realtime_start=${today}` +
     `&include_release_dates_with_no_data=true` +
     `&sort_order=asc` +
     `&limit=${limit}`;


### PR DESCRIPTION
## Summary
- Added `realtime_start` parameter (set to today) to the FRED `/releases/dates` API call so only upcoming releases are returned instead of dates going back to Jan 1
- Updated cache key to include today's date so results refresh daily
- Added test assertion for the new `realtime_start` parameter

## Test plan
- [x] All 13 FRED tests pass
- [x] Build passes
- [ ] After MCP server restart, verify `fred_economic_calendar` returns only future dates

🤖 Generated with [Claude Code](https://claude.com/claude-code)