### PR TITLE
chore: add mcpName for MCP registry discovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "stock-scanner-mcp",
+  "mcpName": "io.github.yyordanov-tradu/stock-scanner-mcp",
   "version": "1.9.0",
   "description": "MCP server providing Claude Code with real-time stock and crypto market data, SEC filings, insider trades, and technical analysis",
   "type": "module",


### PR DESCRIPTION
## Summary
- Adds `mcpName` field to `package.json` for MCP registry indexing
- Pattern used by microsoft/playwright-mcp and other top MCP servers

## Test plan
- [x] `package.json` is valid JSON
- [x] No code changes — metadata only

🤖 Generated with [Claude Code](https://claude.com/claude-code)