### PR TITLE
feat: add MCP tool annotations (readOnlyHint) to all tools

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -142,6 +142,11 @@ async function main() {
       server.registerTool(tool.name, {
         description: tool.description,
         inputSchema: tool.inputSchema,
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          openWorldHint: true,
+        },
       }, async (params) => {
         try {
           return await tool.handler(params as Record<string, unknown>);


### PR DESCRIPTION
## Summary
- Adds `readOnlyHint: true`, `destructiveHint: false`, `openWorldHint: true` annotations to all 47 tool registrations
- Pattern used by microsoft/playwright-mcp and github/github-mcp-server
- Helps LLM clients understand tools are safe to call autonomously and retry freely

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (198/198)
- [x] SDK `ToolAnnotations` type verified in `@modelcontextprotocol/sdk`

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)