### PR TITLE
chore: release v1.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stock-scanner-mcp",
   "mcpName": "io.github.yyordanov-tradu/stock-scanner-mcp",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "MCP server providing Claude Code with real-time stock and crypto market data, SEC filings, insider trades, and technical analysis",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bumps version from 1.9.0 to 1.10.0 (minor)
- Includes sentiment module (Fear & Greed tools) and all recent fixes

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` — 205 tests pass
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)