### PR TITLE
chore: release v1.11.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-**Version:** 1.10.0 — Published on npm as `stock-scanner-mcp`
+**Version:** 1.11.0 — Published on npm as `stock-scanner-mcp`
 **Modules:** 10 implemented (49 tools total)
 
 Planning docs (historical): `docs/architecture.md`, `docs/plans/` — reference only, not actively maintained

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stock-scanner-mcp",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stock-scanner-mcp",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stock-scanner-mcp",
   "mcpName": "io.github.yyordanov-tradu/stock-scanner-mcp",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "MCP server providing Claude Code with real-time stock and crypto market data, SEC filings, insider trades, and technical analysis",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bumps version from 1.10.0 to 1.11.0 (minor)
- Includes HTTP sidecar mode, security fixes, doc updates, deprecated dual-LLM cleanup

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` — 227 tests pass
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)