### PR TITLE
chore: enable Dependabot for dependency security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "yyordanov-tradu"
+    assignees:
+      - "yyordanov-tradu"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+      production-dependencies:
+        dependency-type: "production"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    reviewers:
+      - "yyordanov-tradu"
+    assignees:
+      - "yyordanov-tradu"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` to enable automated dependency vulnerability scanning
- Monitors both npm packages and GitHub Actions versions
- Weekly checks on Mondays, max 5 npm PRs + 3 Actions PRs at a time
- PRs auto-assigned and reviewed by @yyordanov-tradu
- Groups dev dependency updates to reduce PR noise

## What this adds to our security posture
- **Before:** weekly `npm audit` cron (detects, but doesn't fix)
- **After:** Dependabot auto-creates fix PRs within hours of CVE disclosure

## Test plan
- [x] Valid YAML syntax
- [ ] Verify Dependabot tab appears in repo Security settings after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)