### PR TITLE
chore: release v1.12.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-**Version:** 1.11.0 — Published on npm as `stock-scanner-mcp`
+**Version:** 1.12.0 — Published on npm as `stock-scanner-mcp`
 **Modules:** 10 implemented (49 tools total)
 
 Planning docs (historical): `docs/architecture.md`, `docs/plans/` — reference only, not actively maintained

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stock-scanner-mcp",
   "mcpName": "io.github.yyordanov-tradu/stock-scanner-mcp",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "MCP server providing Claude Code with real-time stock and crypto market data, SEC filings, insider trades, and technical analysis",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Release v1.12.0 — bumps version in package.json and CLAUDE.md.

### What's new in v1.12.0

**Sidecar HTTP parity** — all 49 MCP tools now accessible via HTTP sidecar (was 13).

- 37 new HTTP routes across all 10 modules
- `/edgar/filings` alias for clients omitting `sec-` prefix
- Proper input validation: symbol regex, numeric param enforcement (NaN/float rejection), POST body shape validation
- Type-safe implementation: zero `any` in production code
- Fixed top-gainers sort order (was sorting by price, now by % change)
- 291 tests (was 227), including 73 sidecar-specific tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)