### PR TITLE
chore: release v1.13.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-**Version:** 1.12.0 — Published on npm as `stock-scanner-mcp`
+**Version:** 1.13.0 — Published on npm as `stock-scanner-mcp`
 **Modules:** 10 implemented (49 tools total)
 
 Planning docs (historical): `docs/architecture.md`, `docs/plans/` — reference only, not actively maintained

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stock-scanner-mcp",
   "mcpName": "io.github.yyordanov-tradu/stock-scanner-mcp",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "MCP server providing Claude Code with real-time stock and crypto market data, SEC filings, insider trades, and technical analysis",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Bump version to v1.13.0
- Update CLAUDE.md version reference

### What's new in v1.13.0

- **fix:** Add standalone `stock-scanner-install-skills` bin entry to bypass npx argument-dropping (#148)
- **fix:** Add `.catch()` error handler for install-skills entry point
- **docs:** Add §14 Pre-PR Expert Review Loop to development standards
- **test:** Add 5 new tests for `runInstallSkills` and entry point smoke test (1210 → 1215 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)