### PR TITLE
chore: release v1.13.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-**Version:** 1.13.0 — Published on npm as `stock-scanner-mcp`
+**Version:** 1.13.1 — Published on npm as `stock-scanner-mcp`
 **Modules:** 10 implemented (49 tools total)
 
 Planning docs (historical): `docs/architecture.md`, `docs/plans/` — reference only, not actively maintained

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stock-scanner-mcp",
-  "version": "1.11.0",
+  "version": "1.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stock-scanner-mcp",
-      "version": "1.11.0",
+      "version": "1.13.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stock-scanner-mcp",
   "mcpName": "io.github.yyordanov-tradu/stock-scanner-mcp",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "MCP server providing Claude Code with real-time stock and crypto market data, SEC filings, insider trades, and technical analysis",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Release v1.13.1

Patch release — npm SEO keywords for discoverability.

### Changes since v1.13.0
- Added 10 high-value npm keywords: `mcp-server`, `anthropic`, `ai-agent`, `llm-tools`, `cryptocurrency`, `stock-market`, `trading-skills`, `earnings`, `sentiment`, `fear-greed`
- Reorganized keywords by category (AI/MCP, market, analysis, data sources)
- Total keywords: 27 → 37

### Quality Gates
- [x] lint: pass
- [x] tests: 1215/1215 pass
- [x] build: pass
- [x] validate-tools: 49/49

🤖 Generated with [Claude Code](https://claude.com/claude-code)