### PR TITLE
chore: release v1.14.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-**Version:** 1.13.1 — Published on npm as `stock-scanner-mcp`
+**Version:** 1.14.0 — Published on npm as `stock-scanner-mcp`
 **Modules:** 11 implemented (54 tools total)
 
 Planning docs (historical): `docs/architecture.md`, `docs/plans/` — reference only, not actively maintained

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stock-scanner-mcp",
-  "version": "1.13.1",
+  "version": "1.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stock-scanner-mcp",
-      "version": "1.13.1",
+      "version": "1.14.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stock-scanner-mcp",
   "mcpName": "io.github.yyordanov-tradu/stock-scanner-mcp",
-  "version": "1.13.1",
+  "version": "1.14.0",
   "description": "MCP server providing Claude Code with real-time stock and crypto market data, SEC filings, insider trades, and technical analysis",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Release v1.14.0

Minor release — new frankfurter module, README restructure, tool description improvements.

### Changes since v1.13.1

**New module: Frankfurter (5 tools, no API key)**
- `frankfurter_latest` — latest ECB exchange rates for 31 currencies
- `frankfurter_historical` — rates for a specific past date
- `frankfurter_timeseries` — daily rate history (max 90 days)
- `frankfurter_convert` — convert amount between currencies
- `frankfurter_currencies` — list supported currency codes

**README restructure**
- "What You Can Do" examples + highlights at the top
- Quick Start is now 3 steps: MCP config → skills → API keys
- Skills promoted from line 227 to right after Quick Start
- API key table with registration links and descriptions
- Tool reference and architecture collapsed into `<details>`

**Quality**
- 4-expert code review (AI Engineer, TypeScript, QA, Prompt Engineer)
- All review issues addressed
- Tool descriptions improved for LLM disambiguation

### Stats
| Metric | v1.13.1 | v1.14.0 |
|--------|---------|---------|
| Modules | 10 | **11** |
| Tools | 49 | **54** |
| Free tools | 31 | **36** |
| Sidecar routes | 50 | **55** |
| Tests | 278 | **343** |

### Quality Gates
- [x] lint: pass
- [x] tests: 343/343
- [x] build: pass
- [x] validate-tools: 54/54

🤖 Generated with [Claude Code](https://claude.com/claude-code)