### PR TITLE
feat: add beta to alphavantage_overview response

### DIFF
--- a/src/modules/alpha-vantage/__tests__/client.test.ts
+++ b/src/modules/alpha-vantage/__tests__/client.test.ts
@@ -105,6 +105,7 @@ describe("getOverview", () => {
         "52WeekHigh": "199.62",
         "52WeekLow": "143.90",
         AnalystTargetPrice: "195.00",
+        Beta: "1.25",
       }),
     });
 
@@ -114,6 +115,7 @@ describe("getOverview", () => {
     expect(overview.marketCap).toBe(2500000000000);
     expect(overview.peRatio).toBe(28.5);
     expect(overview.sector).toBe("TECHNOLOGY");
+    expect(overview.beta).toBe(1.25);
   });
 });
 

--- a/src/modules/alpha-vantage/client.ts
+++ b/src/modules/alpha-vantage/client.ts
@@ -137,6 +137,7 @@ export interface CompanyOverview {
   week52High: number;
   week52Low: number;
   analystTargetPrice: number;
+  beta: number;
 }
 
 export async function getOverview(apiKey: string, symbol: string): Promise<CompanyOverview> {
@@ -175,6 +176,7 @@ export async function getOverview(apiKey: string, symbol: string): Promise<Compa
     week52High: parseFloat(data["52WeekHigh"]) || 0,
     week52Low: parseFloat(data["52WeekLow"]) || 0,
     analystTargetPrice: parseFloat(data.AnalystTargetPrice) || 0,
+    beta: parseFloat(data.Beta) || 0,
   };
 
   cache.set(cacheKey, overview);

--- a/src/modules/alpha-vantage/index.ts
+++ b/src/modules/alpha-vantage/index.ts
@@ -45,7 +45,7 @@ export function createAlphaVantageModule(apiKey: string): ModuleDefinition {
 
   const overviewTool = {
     name: "alphavantage_overview",
-    description: "Get company fundamentals from Alpha Vantage. Includes PE ratio, market cap, sector, industry, earnings, and analyst target price. Supports batch requests (limit 5). Rate limit: 25 calls/day, 5 calls/min (free tier).",
+    description: "Get company fundamentals from Alpha Vantage. Includes PE ratio, market cap, beta, sector, industry, earnings, and analyst target price. Supports batch requests (limit 5). Rate limit: 25 calls/day, 5 calls/min (free tier).",
     inputSchema: z.object({
       symbols: z.union([z.string(), z.array(z.string())]).describe("One or more stock symbols (e.g. 'AAPL' or ['AAPL', 'MSFT'])"),
     }),


### PR DESCRIPTION
## Summary
- Surfaces the `beta` field from Alpha Vantage OVERVIEW API — already returned by the API but not mapped in our response
- Beta is a core risk metric used in position sizing, portfolio construction, and volatility assessment
- Closes #103

## Changes
- `client.ts`: Added `beta: number` to `CompanyOverview` interface + `parseFloat(data.Beta) || 0` mapping
- `index.ts`: Updated tool description to mention beta
- `client.test.ts`: Added `Beta: "1.25"` to mock + assertion

## Test plan
- [x] `npm run lint` — passes
- [x] `npm test` — 6/6 alpha-vantage tests pass (343 total)
- [x] `npm run validate-tools` — 54/54 tools pass
- [x] `npm run build` — clean build
- [x] Code review — approved (zero critical, zero important)

🤖 Generated with [Claude Code](https://claude.com/claude-code)