### PR TITLE
fix: change sidecar default port from 3100 to 3200

### DIFF
--- a/src/sidecar/index.ts
+++ b/src/sidecar/index.ts
@@ -8,7 +8,7 @@ function parsePort(args: string[]): number {
     const port = Number(args[idx + 1]);
     if (!Number.isNaN(port) && port > 0 && port < 65536) return port;
   }
-  return 3100;
+  return 3200;
 }
 
 function main(): void {


### PR DESCRIPTION
## Summary

- Change sidecar default port from 3100 to 3200
- Port 3100 collides with Grafana Loki when both run on the same host
- The `--port` flag still works for custom overrides

**Companion PR:** yyordanov-tradu/ibkr-bot (same branch name — updates all consumer config)

## Files changed

| File | Change |
|------|--------|
| `src/sidecar/index.ts:11` | Default port 3100 → 3200 |

## Test plan

- [x] `npm run build` — success
- [ ] `node dist/sidecar/index.js` → logs `listening on port 3200`
- [ ] `node dist/sidecar/index.js --port 4000` → logs `listening on port 4000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)