### PR TITLE
docs: add skill installation to Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,14 @@ If you want to use it, start from one of the complete copy-paste examples below.
 
 ## Quick Start
 
-The fastest way to start the server with all free tools and the Market Workspace enabled:
+The fastest way to start the server and install all 19 trading skills:
 
 ```bash
+# 1. Start the server with Market Workspace enabled
 npx -y stock-scanner-mcp --enable-workspace
+
+# 2. In a new terminal, install the trading skills
+npx -y stock-scanner-mcp install-skills
 ```
 
 ### 1. Connect to Claude Desktop (GUI)
@@ -90,10 +94,11 @@ Add to your global config `~/.claude.json` or project-local `.mcp.json`:
 
 This gives you **36 tools** immediately — no API keys needed.
 
-Or enable the **Market Workspace** right away:
+Or enable the **Market Workspace** and install **Trading Skills** right away:
 
 ```bash
 npx -y stock-scanner-mcp --enable-workspace
+npx -y stock-scanner-mcp install-skills
 ```
 
 ### 3. Enable Market Workspace with a complete config


### PR DESCRIPTION
Adds the `install-skills` command to the 'fastest way' Quick Start section so users get both the server and the workflows in one go.