### PR TITLE
fix: server layer — required readOnly, openWorldHint, deduplicate buildModules, validate data-dir (#174, #177, #176, #179)

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
+import * as os from "node:os";
+import * as path from "node:path";
 import { parseConfig } from "../config.js";
 
 describe("parseConfig", () => {
@@ -32,5 +34,35 @@ describe("parseConfig", () => {
     vi.stubEnv("FINNHUB_API_KEY", undefined as unknown as string);
     const config = parseConfig([]);
     expect(config.env.FINNHUB_API_KEY).toBeUndefined();
+  });
+
+  it("rejects --data-dir outside home when workspace enabled", () => {
+    expect(() =>
+      parseConfig(["--enable-workspace", "--data-dir", "/tmp/evil"]),
+    ).toThrow("must be under");
+  });
+
+  it("accepts --data-dir under home when workspace enabled", () => {
+    const validDir = path.join(os.homedir(), "test-scanner-data");
+    const config = parseConfig(["--enable-workspace", "--data-dir", validDir]);
+    expect(config.dataDir).toBe(validDir);
+  });
+
+  it("accepts home directory itself as data-dir", () => {
+    expect(() =>
+      parseConfig(["--enable-workspace", "--data-dir", os.homedir()]),
+    ).not.toThrow();
+  });
+
+  it("does NOT validate data-dir when workspace is disabled", () => {
+    const config = parseConfig(["--data-dir", "/tmp/evil"]);
+    expect(config.enableWorkspace).toBe(false);
+  });
+
+  it("stores resolved absolute path in dataDir", () => {
+    const relPath = path.join(os.homedir(), "relative", "..", "test-data");
+    const config = parseConfig(["--enable-workspace", "--data-dir", relPath]);
+    expect(path.isAbsolute(config.dataDir!)).toBe(true);
+    expect(config.dataDir).not.toContain("..");
   });
 });

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -11,6 +11,7 @@ describe("server module wiring", () => {
     name: "test_tool",
     description: "A test tool",
     inputSchema: z.object({ symbol: z.string() }),
+    readOnly: true,
     handler: async () => successResult("ok"),
   };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,12 +30,13 @@ export function parseConfig(args: string[]): Config {
     }
   }
 
-  if (dataDir) {
+  if (enableWorkspace && dataDir) {
     const resolved = path.resolve(dataDir);
     const home = os.homedir();
     if (!resolved.startsWith(home + path.sep) && resolved !== home) {
       throw new Error(`--data-dir must be under the user home directory (${home}). Got: ${resolved}`);
     }
+    dataDir = resolved;
   }
 
   return {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,6 @@
+import * as path from "node:path";
+import * as os from "node:os";
+
 export interface Config {
   defaultExchange: string;
   enableWorkspace: boolean;
@@ -24,6 +27,14 @@ export function parseConfig(args: string[]): Config {
     } else if (args[i] === "--data-dir" && args[i + 1]) {
       dataDir = args[i + 1];
       i++;
+    }
+  }
+
+  if (dataDir) {
+    const resolved = path.resolve(dataDir);
+    const home = os.homedir();
+    if (!resolved.startsWith(home + path.sep) && resolved !== home) {
+      throw new Error(`--data-dir must be under the user home directory (${home}). Got: ${resolved}`);
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -179,7 +179,7 @@ async function main() {
         description: tool.description,
         inputSchema: tool.inputSchema,
         annotations: {
-          readOnlyHint: tool.readOnly ?? true,
+          readOnlyHint: tool.readOnly,
           destructiveHint: false,
           openWorldHint: true,
         },

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,7 +181,7 @@ async function main() {
         annotations: {
           readOnlyHint: tool.readOnly,
           destructiveHint: false,
-          openWorldHint: true,
+          openWorldHint: tool.openWorld ?? true,
         },
       }, async (params) => {
         try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,36 +54,6 @@ const MODULE_CATALOG: ModuleCatalogEntry[] = [
 
 const TOTAL_TOOLS = MODULE_CATALOG.reduce((n, m) => n + m.toolCount, 0);
 
-function buildModules(config: Config): ModuleDefinition[] {
-  const modules: ModuleDefinition[] = [
-    createTradingviewModule(),
-    createTradingviewCryptoModule(),
-    createSecEdgarModule(),
-    createCoingeckoModule(),
-    createOptionsModule(),
-    createOptionsCboeModule(),
-    createSentimentModule(),
-    createFrankfurterModule(),
-  ];
-
-  if (config.env.FINNHUB_API_KEY) {
-    modules.push(createFinnhubModule(config.env.FINNHUB_API_KEY));
-  }
-
-  if (config.env.ALPHA_VANTAGE_API_KEY) {
-    modules.push(createAlphaVantageModule(config.env.ALPHA_VANTAGE_API_KEY));
-  }
-
-  if (config.env.FRED_API_KEY) {
-    modules.push(createFredModule(config.env.FRED_API_KEY));
-  }
-
-  if (config.enableWorkspace) {
-    modules.push(createWorkspaceModule(config.dataDir || path.join(os.homedir(), ".stock-scanner-mcp"), config.defaultExchange));
-  }
-
-  return modules;
-}
 
 function printHelp(): void {
   const help = `
@@ -163,7 +133,9 @@ async function main() {
   }
 
   const config = parseConfig(args);
-  const allModules = buildModules(config);
+  const allModules = MODULE_CATALOG
+    .map(entry => entry.factory(config))
+    .filter((m): m is ModuleDefinition => m !== null);
   const enabled = resolveEnabledModules(allModules, config.env, config.enabledModules);
 
   const server = new McpServer({

--- a/src/modules/alpha-vantage/index.ts
+++ b/src/modules/alpha-vantage/index.ts
@@ -18,6 +18,7 @@ export function createAlphaVantageModule(apiKey: string): ModuleDefinition {
     inputSchema: z.object({
       symbol: z.string().describe("Stock ticker symbol (e.g. 'AAPL', 'MSFT')"),
     }),
+    readOnly: true,
     handler: withMetadata(async (params) => {
       const symbol = resolveTicker(params.symbol as string).ticker;
       const quote = await getQuote(apiKey, symbol);
@@ -32,6 +33,7 @@ export function createAlphaVantageModule(apiKey: string): ModuleDefinition {
       symbol: z.string().describe("Stock ticker symbol (e.g. 'AAPL')"),
       limit: z.number().optional().describe("Number of days to return (default: 30, max: 100)"),
     }),
+    readOnly: true,
     handler: withMetadata(async (params) => {
       const symbol = resolveTicker(params.symbol as string).ticker;
       const prices = await getDailyPrices(
@@ -49,6 +51,7 @@ export function createAlphaVantageModule(apiKey: string): ModuleDefinition {
     inputSchema: z.object({
       symbols: z.union([z.string(), z.array(z.string())]).describe("One or more stock symbols (e.g. 'AAPL' or ['AAPL', 'MSFT'])"),
     }),
+    readOnly: true,
     handler: withMetadata(async (params) => {
       const inputSymbols = Array.isArray(params.symbols) ? params.symbols : [params.symbols as string];
       const tickers = inputSymbols.map((s: string) => resolveTicker(s).ticker);
@@ -71,6 +74,7 @@ export function createAlphaVantageModule(apiKey: string): ModuleDefinition {
       symbol: z.string().describe("Stock ticker symbol (e.g. 'AAPL')"),
       limit: z.number().optional().describe("Number of quarters to return (default: 8, max: 20)"),
     }),
+    readOnly: true,
     handler: withMetadata(async (params) => {
       const symbol = resolveTicker(params.symbol as string).ticker;
       const earnings = await getEarningsHistory(
@@ -88,6 +92,7 @@ export function createAlphaVantageModule(apiKey: string): ModuleDefinition {
     inputSchema: z.object({
       symbol: z.string().describe("Stock ticker symbol (e.g. 'AAPL')"),
     }),
+    readOnly: true,
     handler: withMetadata(async (params) => {
       const symbol = resolveTicker(params.symbol as string).ticker;
       const dividends = await getDividendHistory(apiKey, symbol);

--- a/src/modules/coingecko/index.ts
+++ b/src/modules/coingecko/index.ts
@@ -10,6 +10,7 @@ const coinTool = {
   inputSchema: z.object({
     coinId: z.string().describe("CoinGecko coin ID / slug (e.g. 'bitcoin', 'ethereum', 'cardano')"),
   }),
+  readOnly: true,
   handler: withMetadata(async (params) => {
     const coin = await getCoinDetail(params.coinId as string);
     return successResult(JSON.stringify(coin, null, 2));
@@ -20,6 +21,7 @@ const trendingTool = {
   name: "coingecko_trending",
   description: "Get trending cryptocurrencies on CoinGecko (top 7 by search popularity in last 24h).",
   inputSchema: z.object({}),
+  readOnly: true,
   handler: withMetadata(async () => {
     const trending = await getTrending();
     return successResult(JSON.stringify(trending, null, 2));
@@ -30,6 +32,7 @@ const globalTool = {
   name: "coingecko_global",
   description: "Get global cryptocurrency market statistics: total market cap, 24h volume, BTC/ETH dominance.",
   inputSchema: z.object({}),
+  readOnly: true,
   handler: withMetadata(async () => {
     const global = await getGlobal();
     return successResult(JSON.stringify(global, null, 2));

--- a/src/modules/finnhub/index.ts
+++ b/src/modules/finnhub/index.ts
@@ -25,6 +25,7 @@ export function createFinnhubModule(apiKey: string): ModuleDefinition {
       category: z.string().optional().describe("Category: general, forex, crypto, merger"),
       limit: z.number().optional().describe("Max results (default: 20, max: 50)"),
     }),
+    readOnly: true,
     handler: withMetadata(async (params) => {
       const news = await getMarketNews(
         apiKey,
@@ -44,6 +45,7 @@ export function createFinnhubModule(apiKey: string): ModuleDefinition {
       to: z.string().describe("To date (YYYY-MM-DD)"),
       limit: z.number().optional().describe("Max results (default: 20, max: 50)"),
     }),
+    readOnly: true,
     handler: withMetadata(async (params) => {
       const symbol = resolveTicker(params.symbol as string).ticker;
       const news = await getCompanyNews(
@@ -66,6 +68,7 @@ export function createFinnhubModule(apiKey: string): ModuleDefinition {
       symbol: z.string().optional().describe("Filter by specific symbol"),
       limit: z.number().optional().describe("Max results to return (default: 20, max: 100)"),
     }),
+    readOnly: true,
     handler: withMetadata(async (params) => {
       const symbol = params.symbol
         ? resolveTicker(params.symbol as string).ticker
@@ -91,6 +94,7 @@ export function createFinnhubModule(apiKey: string): ModuleDefinition {
     inputSchema: z.object({
       symbol: z.string().describe("Stock symbol (e.g. 'AAPL')"),
     }),
+    readOnly: true,
     handler: withMetadata(async (params) => {
       const symbol = resolveTicker(params.symbol as string).ticker;
       const recs = await getAnalystRecommendations(apiKey, symbol);
@@ -109,6 +113,7 @@ export function createFinnhubModule(apiKey: string): ModuleDefinition {
     inputSchema: z.object({
       symbol: z.string().describe("Stock symbol (e.g. 'AAPL')"),
     }),
+    readOnly: true,
     handler: withMetadata(async (params) => {
       const symbol = resolveTicker(params.symbol as string).ticker;
       const profile = await getCompanyProfile(apiKey, symbol);
@@ -122,6 +127,7 @@ export function createFinnhubModule(apiKey: string): ModuleDefinition {
     inputSchema: z.object({
       symbol: z.string().describe("Stock symbol (e.g. 'AAPL')"),
     }),
+    readOnly: true,
     handler: withMetadata(async (params) => {
       const symbol = resolveTicker(params.symbol as string).ticker;
       const peers = await getPeers(apiKey, symbol);
@@ -135,6 +141,7 @@ export function createFinnhubModule(apiKey: string): ModuleDefinition {
     inputSchema: z.object({
       exchange: z.string().default("US").describe("Exchange code. Examples: US, L (London), T (Tokyo), HK"),
     }),
+    readOnly: true,
     handler: withMetadata(async (params) => {
       const exchange = params.exchange as string;
       const status = await getMarketStatus(apiKey, exchange);
@@ -148,6 +155,7 @@ export function createFinnhubModule(apiKey: string): ModuleDefinition {
     inputSchema: z.object({
       symbol: z.string().describe("Stock symbol (e.g. 'AAPL')"),
     }),
+    readOnly: true,
     handler: withMetadata(async (params) => {
       const symbol = resolveTicker(params.symbol as string).ticker;
       const q = await getQuote(apiKey, symbol);
@@ -170,6 +178,7 @@ export function createFinnhubModule(apiKey: string): ModuleDefinition {
     inputSchema: z.object({
       symbol: z.string().describe("Stock symbol (e.g. 'AAPL')"),
     }),
+    readOnly: true,
     handler: withMetadata(async (params) => {
       const symbol = resolveTicker(params.symbol as string).ticker;
       const metrics = await getShortInterest(apiKey, symbol);

--- a/src/modules/frankfurter/index.ts
+++ b/src/modules/frankfurter/index.ts
@@ -34,6 +34,7 @@ const latestTool = {
         "Comma-separated target currencies (e.g. 'EUR,GBP,JPY'). Omit for all 31.",
       ),
   }),
+  readOnly: true,
   handler: withMetadata(async (params) => {
     const result = await getLatestRates(
       params.base as string,
@@ -58,6 +59,7 @@ const historicalTool = {
       .optional()
       .describe("Comma-separated target currencies. Omit for all."),
   }),
+  readOnly: true,
   handler: withMetadata(async (params) => {
     const result = await getHistoricalRates(
       params.base as string,
@@ -90,6 +92,7 @@ const timeseriesTool = {
         "Required: comma-separated target currencies (e.g. 'EUR,GBP')",
       ),
   }),
+  readOnly: true,
   handler: withMetadata(async (params) => {
     const result = await getTimeSeries(
       params.base as string,
@@ -112,6 +115,7 @@ const convertTool = {
     from: currencyCode.describe("Source currency (e.g. 'USD')"),
     to: currencyCode.describe("Target currency (e.g. 'EUR')"),
   }),
+  readOnly: true,
   handler: withMetadata(async (params) => {
     const result = await convertCurrency(
       params.amount as number,
@@ -128,6 +132,7 @@ const currenciesTool = {
     "List all 31 currencies supported by the Frankfurter API with their full names. " +
     "Use to look up valid currency codes before calling other frankfurter tools.",
   inputSchema: z.object({}),
+  readOnly: true,
   handler: withMetadata(async () => {
     const result = await getCurrencies();
     return successResult(JSON.stringify(result, null, 2));

--- a/src/modules/fred/index.ts
+++ b/src/modules/fred/index.ts
@@ -27,6 +27,7 @@ export function createFredModule(apiKey: string): ModuleDefinition {
         .default(60)
         .describe("Max raw results to fetch before filtering (default: 60)"),
     }),
+    readOnly: true,
     handler: withMetadata(async (params) => {
       const releases = await getEconomicCalendar(apiKey, params.limit as number);
       return successResult(JSON.stringify(releases, null, 2));
@@ -47,6 +48,7 @@ export function createFredModule(apiKey: string): ModuleDefinition {
         .string()
         .describe("FRED series ID or alias (e.g. 'cpi', 'UNRATE', 'treasury_10y')"),
     }),
+    readOnly: true,
     handler: withMetadata(async (params) => {
       const result = await getIndicator(apiKey, params.series_id as string);
       return successResult(JSON.stringify(result, null, 2));
@@ -73,6 +75,7 @@ export function createFredModule(apiKey: string): ModuleDefinition {
         .default("lin")
         .describe("Units: lin=level, pch=% change, pc1=YoY % change (default: lin)"),
     }),
+    readOnly: true,
     handler: withMetadata(async (params) => {
       const result = await getIndicatorHistory(
         apiKey,
@@ -96,6 +99,7 @@ export function createFredModule(apiKey: string): ModuleDefinition {
       query: z.string().describe("Search keywords (e.g. 'consumer price index', 'housing starts')"),
       limit: z.number().optional().default(10).describe("Max results (default: 10, max: 50)"),
     }),
+    readOnly: true,
     handler: withMetadata(async (params) => {
       const results = await searchSeries(apiKey, params.query as string, params.limit as number);
       return successResult(JSON.stringify(results, null, 2));

--- a/src/modules/options-cboe/index.ts
+++ b/src/modules/options-cboe/index.ts
@@ -17,6 +17,7 @@ export function createOptionsCboeModule(): ModuleDefinition {
         type: z.enum(["total", "equity", "index"]).optional().describe("Ratio type (default: total)"),
         days: z.number().optional().describe("Number of recent trading days to return (default: 30, max: 252)"),
       }),
+      readOnly: true,
       handler: withMetadata(async (params) => {
         const days = Math.min(Math.max((params.days as number) ?? 30, 1), 252);
         const data = await getPutCallRatio((params.type as string) ?? "total", days);

--- a/src/modules/options/index.ts
+++ b/src/modules/options/index.ts
@@ -25,6 +25,7 @@ const expirationsTool: ToolDefinition = {
   inputSchema: z.object({
     symbol: symbolSchema,
   }),
+  readOnly: true,
   handler: withMetadata(async (params) => {
     const chain = await fetchOptionChain(params.symbol as string);
     const dates = chain.expirationDates.map(
@@ -60,6 +61,7 @@ const chainTool: ToolDefinition = {
     all_strikes: z.boolean().optional()
       .describe("Return all strikes instead of centering around ATM (default: false)"),
   }),
+  readOnly: true,
   handler: withMetadata(async (params) => {
     const expUnix = parseExpiration(params.expiration as string | undefined);
     const chain = await fetchOptionChain(params.symbol as string, expUnix);
@@ -120,6 +122,7 @@ const unusualActivityTool: ToolDefinition = {
     side: z.enum(["call", "put", "both"]).optional()
       .describe("Filter by option type (default: both)"),
   }),
+  readOnly: true,
   handler: withMetadata(async (params) => {
     const chain = await fetchOptionChain(params.symbol as string);
     const minRatio = (params.volume_oi_ratio as number) ?? 3.0;
@@ -164,6 +167,7 @@ const maxPainTool: ToolDefinition = {
     expiration: z.string().optional()
       .describe("Expiration date as YYYY-MM-DD. If omitted, uses nearest."),
   }),
+  readOnly: true,
   handler: withMetadata(async (params) => {
     const expUnix = parseExpiration(params.expiration as string | undefined);
     const chain = await fetchOptionChain(params.symbol as string, expUnix);
@@ -191,6 +195,7 @@ const impliedMoveTool: ToolDefinition = {
     expiration: z.string().optional()
       .describe("Expiration date as YYYY-MM-DD. If omitted, uses nearest."),
   }),
+  readOnly: true,
   handler: withMetadata(async (params) => {
     const expUnix = parseExpiration(params.expiration as string | undefined);
     const chain = await fetchOptionChain(params.symbol as string, expUnix);

--- a/src/modules/sec-edgar/index.ts
+++ b/src/modules/sec-edgar/index.ts
@@ -48,6 +48,7 @@ export function createSecEdgarModule(): ModuleDefinition {
             .optional()
             .describe("Max results (default: 20, max: 50)"),
         }),
+        readOnly: true,
         handler: withMetadata(async (params) => {
           const resolvedTickers = (params.tickers as string[] | undefined)?.map(t => resolveTicker(t).ticker);
           const filings = await searchFilings({
@@ -75,6 +76,7 @@ export function createSecEdgarModule(): ModuleDefinition {
             .optional()
             .describe("Max results (default: 10, max: 50)"),
         }),
+        readOnly: true,
         handler: withMetadata(async (params) => {
           const ticker = resolveTicker(params.ticker as string).ticker;
           const filings = await getCompanyFilings({
@@ -94,6 +96,7 @@ export function createSecEdgarModule(): ModuleDefinition {
         inputSchema: z.object({
           ticker: z.string().describe("Stock ticker symbol (e.g. 'AAPL')"),
         }),
+        readOnly: true,
         handler: withMetadata(async (params) => {
           const ticker = resolveTicker(params.ticker as string).ticker;
           const facts = await getCompanyFacts(ticker);
@@ -107,6 +110,7 @@ export function createSecEdgarModule(): ModuleDefinition {
           ticker: z.string().describe("Stock ticker symbol (e.g. 'AAPL')"),
           limit: z.number().optional().describe("Max results (default: 10)"),
         }),
+        readOnly: true,
         handler: withMetadata(async (params) => {
           const ticker = resolveTicker(params.ticker as string).ticker;
           const trades = await getInsiderTrades(
@@ -128,6 +132,7 @@ export function createSecEdgarModule(): ModuleDefinition {
             .describe("Stock ticker (e.g. 'AAPL') or institutional manager name (e.g. 'Berkshire Hathaway')"),
           limit: z.number().optional().describe("Max results (default: 10)"),
         }),
+        readOnly: true,
         handler: withMetadata(async (params) => {
           const res = resolveTicker(params.query as string);
           const query = res.ticker;
@@ -146,6 +151,7 @@ export function createSecEdgarModule(): ModuleDefinition {
           ticker: z.string().describe("Stock ticker symbol (e.g. 'AAPL')"),
           limit: z.number().optional().describe("Max results (default: 10)"),
         }),
+        readOnly: true,
         handler: withMetadata(async (params) => {
           const ticker = resolveTicker(params.ticker as string).ticker;
           const filings = await getOwnershipFilings(

--- a/src/modules/sentiment/index.ts
+++ b/src/modules/sentiment/index.ts
@@ -14,6 +14,7 @@ const fearGreedTool = {
     "Also includes previous close, 1-week, 1-month, and 1-year scores for trend context. " +
     "Use this to gauge overall market sentiment before analyzing individual stocks.",
   inputSchema: z.object({}),
+  readOnly: true,
   handler: withMetadata(async () => {
     const result = await getFearAndGreed();
     return successResult(JSON.stringify(result, null, 2));
@@ -28,6 +29,7 @@ const cryptoFearGreedTool = {
     "Based on Bitcoin volatility, market volume, social media, surveys, dominance, and trends. " +
     "Use this alongside coingecko tools for crypto market context.",
   inputSchema: z.object({}),
+  readOnly: true,
   handler: withMetadata(async () => {
     const result = await getCryptoFearAndGreed();
     return successResult(JSON.stringify(result, null, 2));

--- a/src/modules/tradingview-crypto/index.ts
+++ b/src/modules/tradingview-crypto/index.ts
@@ -44,6 +44,7 @@ export function createTradingviewCryptoModule(): ModuleDefinition {
             .describe("Timeframe: '1m','5m','15m','1h','4h','1d','1W','1M'. Default: '1d'"),
           limit: z.number().optional().describe("Max results (default: 50, max: 200)"),
         }),
+        readOnly: true,
         handler: withMetadata(async (params) => {
           const majorOnly = (params.major_only as boolean) ?? true;
           let filters = (params.filters as any[]) || [];
@@ -69,6 +70,7 @@ export function createTradingviewCryptoModule(): ModuleDefinition {
             .array(z.string())
             .describe("Crypto pair symbols (e.g. ['BTCUSDT', 'ETHUSDT'])"),
         }),
+        readOnly: true,
         handler: withMetadata(async (params) => {
           const resolvedTickers = (params.symbols as string[]).map(s => {
             const res = resolveTicker(s, "BINANCE");
@@ -96,6 +98,7 @@ export function createTradingviewCryptoModule(): ModuleDefinition {
           symbols: z.array(z.string()).describe("Crypto symbols (e.g. ['BTCUSDT'])"),
           timeframe: z.string().optional().describe("Timeframe. Default: '1d'"),
         }),
+        readOnly: true,
         handler: withMetadata(async (params) => {
           const resolvedTickers = (params.symbols as string[]).map(s => {
             const res = resolveTicker(s, "BINANCE");
@@ -134,6 +137,7 @@ export function createTradingviewCryptoModule(): ModuleDefinition {
           exchange: z.string().optional().describe("Specific exchange (e.g. BINANCE)"),
           limit: z.number().optional().describe("Number of results (default: 20, max: 50)"),
         }),
+        readOnly: true,
         handler: withMetadata(async (params) => {
           const filters: any[] = [{ left: "change", operation: "greater", right: 0 }];
           if (params.exchange) {

--- a/src/modules/tradingview/index.ts
+++ b/src/modules/tradingview/index.ts
@@ -27,6 +27,7 @@ export function createTradingviewModule(): ModuleDefinition {
           timeframe: z.string().optional().describe("Timeframe: 1m, 5m, 15m, 1h, 4h, 1d (default), 1W, 1M"),
           limit: z.number().optional().describe("Max rows (default 50)"),
         }),
+        readOnly: true,
         handler: withMetadata(async (input) => {
           const rows = await scanStocks(input);
           return successResult(JSON.stringify(rows, null, 2));
@@ -38,6 +39,7 @@ export function createTradingviewModule(): ModuleDefinition {
         inputSchema: z.object({
           tickers: z.array(z.string()).min(2).max(5).describe("2-5 stock tickers to compare (e.g. AAPL, MSFT)"),
         }),
+        readOnly: true,
         handler: withMetadata(async (input) => {
           const resolvedTickers = input.tickers.map((t: string) => resolveTicker(t).full);
           const columns = [
@@ -59,6 +61,7 @@ export function createTradingviewModule(): ModuleDefinition {
         inputSchema: z.object({
           tickers: z.array(z.string()).describe("Stock tickers, e.g. ['AAPL', 'MSFT']"),
         }),
+        readOnly: true,
         handler: withMetadata(async (input) => {
           const resolvedTickers = input.tickers.map((t: string) => resolveTicker(t).full);
           const rows = await scanStocks({
@@ -79,6 +82,7 @@ export function createTradingviewModule(): ModuleDefinition {
           tickers: z.array(z.string()).describe("Stock tickers, e.g. ['AAPL', 'IBM']"),
           timeframe: z.string().optional().describe("Timeframe (default: 1d)"),
         }),
+        readOnly: true,
         handler: withMetadata(async (input) => {
           const technicalCols = [
             "Recommend.All", "Recommend.MA", "Recommend.Other",
@@ -104,6 +108,7 @@ export function createTradingviewModule(): ModuleDefinition {
           include_otc: z.boolean().optional().describe("Whether to include OTC penny stocks (default: false)"),
           limit: z.number().optional().describe("Max results (default 20)"),
         }),
+        readOnly: true,
         handler: withMetadata(async (input) => {
           const filters = [];
           if (!input.include_otc) {
@@ -127,6 +132,7 @@ export function createTradingviewModule(): ModuleDefinition {
           include_otc: z.boolean().optional().describe("Whether to include OTC penny stocks (default: false)"),
           limit: z.number().optional().describe("Max results (default 20)"),
         }),
+        readOnly: true,
         handler: withMetadata(async (input) => {
           const filters = [];
           if (!input.include_otc) {
@@ -151,6 +157,7 @@ export function createTradingviewModule(): ModuleDefinition {
           include_otc: z.boolean().optional().describe("Whether to include OTC penny stocks (default: false)"),
           limit: z.number().optional().describe("Max results (default 20)"),
         }),
+        readOnly: true,
         handler: withMetadata(async (input) => {
           const filters = [];
           if (!input.include_otc) {
@@ -169,6 +176,7 @@ export function createTradingviewModule(): ModuleDefinition {
         name: "tradingview_market_indices",
         description: "Get real-time values for major market indices: VIX (volatility), S&P 500, NASDAQ Composite, and Dow Jones. Essential for gauging broad market conditions, risk sentiment, and options pricing context.",
         inputSchema: z.object({}),
+        readOnly: true,
         handler: withMetadata(async () => {
           const tickers = ["CBOE:VIX", "SP:SPX", "NASDAQ:NDX", "TVC:DJI"];
           const columns = [
@@ -183,6 +191,7 @@ export function createTradingviewModule(): ModuleDefinition {
         name: "tradingview_sector_performance",
         description: "Get performance of S&P 500 sector ETFs (XLK, XLF, XLE, XLV, XLI, XLP, XLU, XLY, XLC, XLRE, XLB). Shows which sectors are leading or lagging today. Essential for sector rotation analysis.",
         inputSchema: z.object({}),
+        readOnly: true,
         handler: withMetadata(async () => {
           const sectorEtfs = [
             "AMEX:XLK", "AMEX:XLF", "AMEX:XLE", "AMEX:XLV", "AMEX:XLI",
@@ -205,6 +214,7 @@ export function createTradingviewModule(): ModuleDefinition {
           exchange: z.string().optional().describe("Exchange filter"),
           limit: z.number().optional().describe("Max results (default 20)"),
         }),
+        readOnly: true,
         handler: withMetadata(async (input) => {
           const rows = await scanStocks({
             exchange: input.exchange,

--- a/src/modules/workspace/__tests__/tools.test.ts
+++ b/src/modules/workspace/__tests__/tools.test.ts
@@ -21,6 +21,12 @@ describe("Workspace Tools", () => {
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
+  it("all workspace tools have openWorld: false", () => {
+    for (const tool of workspaceTools) {
+      expect(tool.openWorld, `${tool.name} missing openWorld: false`).toBe(false);
+    }
+  });
+
   it("P2 Fix: tool results include _meta and return parseable JSON", async () => {
     const tool = getTool("workspace_update_profile");
     const result: ToolResult = await tool.handler({

--- a/src/modules/workspace/index.ts
+++ b/src/modules/workspace/index.ts
@@ -17,6 +17,7 @@ export function createWorkspaceModule(dataDir: string, defaultExchange = "NASDAQ
         description: "Get the current user's trading profile and workspace settings.",
         inputSchema: z.object({}),
         readOnly: true,
+        openWorld: false,
         handler: withMetadata(async () => {
           const { data } = await storage.load();
           return successResult(JSON.stringify(data.profile, null, 2));
@@ -31,6 +32,7 @@ export function createWorkspaceModule(dataDir: string, defaultExchange = "NASDAQ
           workflowCadence: z.enum(["daily", "weekly"]).optional(),
         }),
         readOnly: false,
+        openWorld: false,
         handler: withMetadata(async ({ tradingStyle, assetFocus, workflowCadence }) => {
           const { data, lastModified } = await storage.load();
           
@@ -53,6 +55,7 @@ export function createWorkspaceModule(dataDir: string, defaultExchange = "NASDAQ
         description: "List all watchlists and their instruments.",
         inputSchema: z.object({}),
         readOnly: true,
+        openWorld: false,
         handler: withMetadata(async () => {
           const { data } = await storage.load();
           return successResult(JSON.stringify(data.watchlists, null, 2));
@@ -65,6 +68,7 @@ export function createWorkspaceModule(dataDir: string, defaultExchange = "NASDAQ
           name: z.string().describe("The ID/name of the watchlist (e.g., 'core', 'swing')"),
         }),
         readOnly: false,
+        openWorld: false,
         handler: withMetadata(async ({ name }) => {
           const { data, lastModified } = await storage.load();
           
@@ -95,6 +99,7 @@ export function createWorkspaceModule(dataDir: string, defaultExchange = "NASDAQ
           symbols: z.array(z.string()).describe("Raw symbols to track (e.g., ['AAPL', 'BTC'])"),
         }),
         readOnly: false,
+        openWorld: false,
         handler: withMetadata(async ({ name, symbols }) => {
           const { data, lastModified } = await storage.load();
           
@@ -138,6 +143,7 @@ export function createWorkspaceModule(dataDir: string, defaultExchange = "NASDAQ
           symbol: z.string().describe("The raw symbol (e.g., 'AAPL')"),
         }),
         readOnly: true,
+        openWorld: false,
         handler: withMetadata(async ({ symbol }) => {
           const { data } = await storage.load();
           const resolved = resolveTicker(symbol, data.profile.defaultExchange);
@@ -163,6 +169,7 @@ export function createWorkspaceModule(dataDir: string, defaultExchange = "NASDAQ
           timeframe: z.string().optional(),
         }),
         readOnly: false,
+        openWorld: false,
         handler: withMetadata(async ({ symbol, summary, bullCase, bearCase, catalyst, timeframe }) => {
           const { data, lastModified } = await storage.load();
           const resolved = resolveTicker(symbol, data.profile.defaultExchange);

--- a/src/modules/workspace/index.ts
+++ b/src/modules/workspace/index.ts
@@ -1,19 +1,11 @@
 import { z } from "zod";
-import { ModuleDefinition, successResult, errorResult, ToolResult } from "../../shared/types.js";
+import { ModuleDefinition, successResult, errorResult } from "../../shared/types.js";
 import { StorageManager } from "./storage.js";
 import { resolveTicker } from "../../shared/resolver.js";
 import { withMetadata } from "../../shared/utils.js";
 
 export function createWorkspaceModule(dataDir: string, defaultExchange = "NASDAQ"): ModuleDefinition {
   const storage = new StorageManager(dataDir, defaultExchange);
-
-  const wrapHandler = (handler: (args: any) => Promise<ToolResult>) => async (args: any) => {
-    try {
-      return await handler(args);
-    } catch (e) {
-      return errorResult(e instanceof Error ? e.message : String(e));
-    }
-  };
 
   return {
     name: "workspace",

--- a/src/modules/workspace/storage.ts
+++ b/src/modules/workspace/storage.ts
@@ -85,23 +85,25 @@ export class StorageManager {
     const dir = path.dirname(this.filePath);
     await fs.mkdir(dir, { recursive: true });
 
-    // Ensure lock file exists
+    // Check lock file BEFORE writing to it
+    await this.assertNotSymlink(this.lockPath);
+
+    // Ensure lock file exists (safe now — verified not a symlink)
     await fs.writeFile(this.lockPath, "", "utf-8");
 
     let release: (() => Promise<void>) | undefined;
-    
+
     try {
       // Acquire lock on the dedicated lock file
-      release = await lock(this.lockPath, { 
+      release = await lock(this.lockPath, {
         retries: {
           retries: 5,
           minTimeout: 100,
           maxTimeout: 1000,
-        }
+        },
       });
 
       await this.assertNotSymlink(this.filePath);
-      await this.assertNotSymlink(this.lockPath);
 
       const fileExists = await this.exists();
 
@@ -125,9 +127,13 @@ export class StorageManager {
       const bakPath = `${this.filePath}.bak`;
       const content = JSON.stringify(data, null, 2);
 
+      // Check tmp/bak paths before writing
+      await this.assertNotSymlink(tmpPath);
+      await this.assertNotSymlink(bakPath);
+
       // Atomic write
       await fs.writeFile(tmpPath, content, "utf-8");
-      
+
       if (fileExists) {
         await fs.copyFile(this.filePath, bakPath);
       }

--- a/src/modules/workspace/storage.ts
+++ b/src/modules/workspace/storage.ts
@@ -44,18 +44,25 @@ export class StorageManager {
       return { data: defaultData, lastModified: 0 };
     }
 
-    const raw = await fs.readFile(this.filePath, "utf-8");
-    const stat = await fs.stat(this.filePath);
-    
-    let parsed: unknown;
+    const fh = await fs.open(this.filePath, "r");
     try {
-      parsed = JSON.parse(raw);
-    } catch (e) {
-      throw new Error(`Workspace file corrupted: ${e instanceof Error ? e.message : String(e)}`);
-    }
+      const [raw, stat] = await Promise.all([
+        fh.readFile("utf-8"),
+        fh.stat(),
+      ]);
 
-    const data = WorkspaceSchema.parse(parsed);
-    return { data, lastModified: stat.mtimeMs };
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(raw);
+      } catch (e) {
+        throw new Error(`Workspace file corrupted: ${e instanceof Error ? e.message : String(e)}`);
+      }
+
+      const data = WorkspaceSchema.parse(parsed);
+      return { data, lastModified: stat.mtimeMs };
+    } finally {
+      await fh.close();
+    }
   }
 
   async save(data: Workspace, expectedLastModified: number): Promise<number> {

--- a/src/modules/workspace/storage.ts
+++ b/src/modules/workspace/storage.ts
@@ -19,6 +19,20 @@ export class StorageManager {
     this.defaultExchange = defaultExchange;
   }
 
+  private async assertNotSymlink(filePath: string): Promise<void> {
+    try {
+      const stat = await fs.lstat(filePath);
+      if (stat.isSymbolicLink()) {
+        throw new Error(`Refusing to operate on symlink: ${filePath}`);
+      }
+    } catch (e: unknown) {
+      if (e instanceof Error && "code" in e && (e as NodeJS.ErrnoException).code === "ENOENT") {
+        return; // file doesn't exist yet, OK
+      }
+      throw e;
+    }
+  }
+
   async exists(): Promise<boolean> {
     try {
       await fs.access(this.filePath);
@@ -29,6 +43,8 @@ export class StorageManager {
   }
 
   async load(): Promise<LoadResult> {
+    await this.assertNotSymlink(this.filePath);
+
     if (!(await this.exists())) {
       const defaultData = WorkspaceSchema.parse({
         schemaVersion: 1,
@@ -83,6 +99,9 @@ export class StorageManager {
           maxTimeout: 1000,
         }
       });
+
+      await this.assertNotSymlink(this.filePath);
+      await this.assertNotSymlink(this.lockPath);
 
       const fileExists = await this.exists();
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -17,7 +17,7 @@ export interface ToolDefinition {
   name: string;
   description: string;
   inputSchema: z.ZodType<any>;
-  readOnly?: boolean;
+  readOnly: boolean;
   handler: (args: any) => Promise<ToolResult>;
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -18,6 +18,7 @@ export interface ToolDefinition {
   description: string;
   inputSchema: z.ZodType<any>;
   readOnly: boolean;
+  openWorld?: boolean;
   handler: (args: any) => Promise<ToolResult>;
 }
 


### PR DESCRIPTION
## Summary
Track C from the 4-expert Market Workspace review. Fixes 4 issues:

- **#174**: Make `readOnly` required in `ToolDefinition` — added to all 54 tools across 11 modules
- **#177**: Add `openWorld` property, set `false` for workspace tools
- **#176**: Eliminate `buildModules()` duplication — derived from `MODULE_CATALOG`
- **#179**: Validate `--data-dir` path — reject paths outside home directory

## Test plan
- [x] `npm test` — 354 tests passing
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] TypeScript compiler catches any missing `readOnly` fields

Closes #174, closes #177, closes #176, closes #179