### PR TITLE
feat: add Reddit sentiment module — 3 tools for trending, mentions, sentiment (#195)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Status
 
 **Version:** 1.16.0 — Published on npm as `stock-scanner-mcp`
-**Modules:** 12 implemented (61 tools total)
+**Modules:** 13 implemented (64 tools total)
 
 Planning docs (historical): `docs/architecture.md`, `docs/plans/` — reference only, not actively maintained
 
@@ -41,7 +41,8 @@ stock-scanner-mcp/
 │   │   ├── options-cboe/     # CBOE put/call ratio sentiment (no key)
 │   │   ├── fred/             # US economic data — calendar, indicators (FRED_API_KEY)
 │   │   ├── sentiment/        # Market & crypto Fear & Greed sentiment (no key)
-│   │   └── frankfurter/      # Forex exchange rates — ECB daily rates (no key)
+│   │   ├── frankfurter/      # Forex exchange rates — ECB daily rates (no key)
+│   │   └── reddit/           # Reddit trending tickers & sentiment (no key)
 │   ├── sidecar/
 │   │   ├── index.ts          # HTTP sidecar entry point (port 3100)
 │   │   └── server.ts         # HTTP request handler (55 endpoints)
@@ -103,6 +104,7 @@ node dist/index.js --modules tradingview,finnhub  # Run specific modules
 | fred | FRED_API_KEY | When key set |
 | sentiment | (none) | Always |
 | frankfurter | (none) | Always |
+| reddit | (none) | Always |
 
 ## Development Standards
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Copy this complete config block into your config file:
 }
 ```
 
-This gives you **43 tools** immediately with no API keys. API keys are optional and free — they unlock 18 additional tools for real-time quotes, news, earnings, and economic data. See [API Keys](#api-keys-optional) below for where to get them.
+This gives you **49 tools** immediately with no API keys. API keys are optional and free — they unlock 18 additional tools for real-time quotes, news, earnings, and economic data. See [API Keys](#api-keys-optional) below for where to get them.
 
 > **Minimal config** — if you don't want workspace or API keys, use this instead:
 > ```json
@@ -48,7 +48,7 @@ This gives you **43 tools** immediately with no API keys. API keys are optional 
 >   }
 > }
 > ```
-> This gives you **36 stateless tools** with no local data storage.
+> This gives you **42 stateless tools** with no local data storage.
 
 Restart Claude Desktop after saving. Claude Code picks up the config automatically.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Copy this complete config block into your config file:
 }
 ```
 
-This gives you **49 tools** immediately with no API keys. API keys are optional and free — they unlock 18 additional tools for real-time quotes, news, earnings, and economic data. See [API Keys](#api-keys-optional) below for where to get them.
+This gives you **46 tools** immediately with no API keys. API keys are optional and free — they unlock 18 additional tools for real-time quotes, news, earnings, and economic data. See [API Keys](#api-keys-optional) below for where to get them.
 
 > **Minimal config** — if you don't want workspace or API keys, use this instead:
 > ```json
@@ -48,7 +48,7 @@ This gives you **49 tools** immediately with no API keys. API keys are optional 
 >   }
 > }
 > ```
-> This gives you **42 stateless tools** with no local data storage.
+> This gives you **39 stateless tools** with no local data storage.
 
 Restart Claude Desktop after saving. Claude Code picks up the config automatically.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A modular MCP server for Claude Code and Claude Desktop that provides real-time access to stock and crypto market data. Scan markets, check technicals, monitor insider trades, track earnings, analyze options flow, and optionally save your own watchlists and thesis notes from one server.
 
-**61 tools** across **12 modules** — 9 modules work with zero API keys, including an optional stateful Market Workspace.
+**64 tools** across **13 modules** — 9 modules work with zero API keys, including an optional stateful Market Workspace.
 
 ## Quick Start
 
@@ -97,7 +97,7 @@ Once answered, it saves your profile and creates a `core` watchlist:
 
 You can also skip the skill and ask Claude directly: *"Set up my workspace — I'm a swing trader, create a core watchlist with MARA, HOOD, BTC, daily reviews."*
 
-**That's it.** You now have 61 tools, 19 skills, and a personalized workspace. Try `/workspace-morning-brief` for your first tailored market scan.
+**That's it.** You now have 64 tools, 19 skills, and a personalized workspace. Try `/workspace-morning-brief` for your first tailored market scan.
 
 ## What You Can Do
 
@@ -220,6 +220,7 @@ For the full list of workspace tools, see the [tool reference](#workspace--perso
 | options-cboe | 1 | None | CBOE put/call ratio sentiment indicator |
 | sentiment | 2 | None | CNN Fear & Greed Index, Crypto Fear & Greed Index |
 | frankfurter | 5 | None | Forex exchange rates — 31 currencies from ECB (daily reference rates) |
+| reddit | 3 | None | Reddit trending tickers, mention tracking, and sentiment from r/wallstreetbets, r/stocks, r/investing, r/options |
 | workspace | 7 | None | Optional stateful profile, watchlists, and thesis tracking for personalized workflows (`--enable-workspace`) |
 | finnhub | 9 | `FINNHUB_API_KEY` | Quotes, news, earnings, analyst ratings, short interest |
 | alpha-vantage | 5 | `ALPHA_VANTAGE_API_KEY` | Quotes, daily prices, fundamentals, earnings, dividends |
@@ -227,9 +228,9 @@ For the full list of workspace tools, see the [tool reference](#workspace--perso
 
 Modules auto-enable when their API key is set. No-key modules are always enabled, except `workspace`, which requires `--enable-workspace`.
 
-For a complete list of every tool with descriptions, see the [Full Tool Reference](#full-tool-reference-61-tools) below.
+For a complete list of every tool with descriptions, see the [Full Tool Reference](#full-tool-reference-64-tools) below.
 
-## Full Tool Reference (61 tools)
+## Full Tool Reference (64 tools)
 
 ### TradingView — Stock Scanning (no API key)
 
@@ -306,6 +307,14 @@ For a complete list of every tool with descriptions, see the [Full Tool Referenc
 | `frankfurter_timeseries` | Daily rate history for a date range (max 90 days) |
 | `frankfurter_convert` | Convert an amount between two currencies |
 | `frankfurter_currencies` | List all supported currency codes |
+
+### Reddit — Trending Tickers & Sentiment (no API key)
+
+| Tool | Description |
+|------|-------------|
+| `reddit_trending` | Trending stock tickers from Reddit by mention frequency across r/wallstreetbets, r/stocks, r/investing, r/options |
+| `reddit_mentions` | Mention count and top posts for a specific ticker across Reddit investing subreddits |
+| `reddit_sentiment` | Keyword-based sentiment analysis (bullish/bearish/neutral) for a ticker from Reddit discussions |
 
 ### Workspace — Personalized Context (optional, no API key)
 
@@ -443,7 +452,8 @@ src/
 │   ├── alpha-vantage/    # 5 tools — quotes, fundamentals, dividends
 │   ├── fred/             # 4 tools — economic calendar, indicators, historical data
 │   ├── sentiment/        # 2 tools — Fear & Greed indexes (market + crypto)
-│   └── frankfurter/      # 5 tools — forex exchange rates (ECB, 31 currencies)
+│   ├── frankfurter/      # 5 tools — forex exchange rates (ECB, 31 currencies)
+│   └── reddit/           # 3 tools — trending tickers, mentions, sentiment from Reddit
 ├── sidecar/
 │   ├── index.ts          # HTTP sidecar entry point (port 3200)
 │   └── server.ts         # HTTP request handler (55 endpoints)

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import { createOptionsCboeModule } from "./modules/options-cboe/index.js";
 import { createFredModule } from "./modules/fred/index.js";
 import { createSentimentModule } from "./modules/sentiment/index.js";
 import { createFrankfurterModule } from "./modules/frankfurter/index.js";
+import { createRedditModule } from "./modules/reddit/index.js";
 import { createWorkspaceModule } from "./modules/workspace/index.js";
 import type { Config } from "./config.js";
 import * as path from "node:path";
@@ -49,6 +50,7 @@ const MODULE_CATALOG: ModuleCatalogEntry[] = [
   { name: "fred", envVar: "FRED_API_KEY", toolCount: 4, factory: (config) => config.env.FRED_API_KEY ? createFredModule(config.env.FRED_API_KEY) : null },
   { name: "sentiment", envVar: null, toolCount: 2, factory: () => createSentimentModule() },
   { name: "frankfurter", envVar: null, toolCount: 5, factory: () => createFrankfurterModule() },
+  { name: "reddit", envVar: null, toolCount: 3, factory: () => createRedditModule() },
   { name: "workspace", envVar: null, toolCount: 7, factory: (config) => config.enableWorkspace ? createWorkspaceModule(config.dataDir || path.join(os.homedir(), ".stock-scanner-mcp"), config.defaultExchange) : null },
 ];
 
@@ -71,7 +73,7 @@ OPTIONS
   --enable-workspace      Enable stateful workspace (watchlists, theses, profile)
   --data-dir <path>       Directory for workspace storage (default: ~/.stock-scanner-mcp)
 
-MODULES (61 tools total)
+MODULES (64 tools total)
   tradingview        10 tools Stock scanning, quotes, technicals       (no key)
   tradingview-crypto 4 tools  Crypto pair scanning and technicals      (no key)
   sec-edgar          6 tools  SEC filings, insider trades, holdings    (no key)
@@ -80,6 +82,7 @@ MODULES (61 tools total)
   options-cboe       1 tool   CBOE put/call ratio sentiment            (no key)
   sentiment          2 tools  Market & crypto Fear & Greed sentiment   (no key)
   frankfurter        5 tools  Forex exchange rates and conversion       (no key)
+  reddit             3 tools  Reddit trending tickers and sentiment     (no key)
   workspace          7 tools  Stateful watchlists, theses, and profile  (no key)
   finnhub            9 tools  Quotes, profiles, peers, news, earnings  (FINNHUB_API_KEY)
   alpha-vantage      5 tools  Stock quotes, fundamentals, dividends    (ALPHA_VANTAGE_API_KEY)

--- a/src/modules/reddit/__tests__/client.test.ts
+++ b/src/modules/reddit/__tests__/client.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ── Helper: build a Reddit listing response ──────────────────────────────────
+
+function makeRedditListing(
+  posts: Array<{
+    title: string;
+    selftext?: string;
+    score?: number;
+    num_comments?: number;
+    created_utc?: number;
+    permalink?: string;
+    subreddit?: string;
+  }>,
+) {
+  return {
+    data: {
+      children: posts.map((p) => ({
+        data: {
+          title: p.title,
+          selftext: p.selftext ?? "",
+          score: p.score ?? 1,
+          num_comments: p.num_comments ?? 0,
+          created_utc: p.created_utc ?? 1712500000,
+          permalink: p.permalink ?? "/r/stocks/comments/abc123/test",
+          subreddit: p.subreddit ?? "stocks",
+        },
+      })),
+    },
+  };
+}
+
+function mockFetchOk(data: unknown) {
+  (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    ok: true,
+    json: async () => data,
+  });
+}
+
+// ── extractTickers ───────────────────────────────────────────────────────────
+
+describe("extractTickers", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("extracts $TICKER cashtags", async () => {
+    const { extractTickers } = await import("../client.js");
+    expect(extractTickers("I like $AAPL and $TSLA")).toEqual(["AAPL", "TSLA"]);
+  });
+
+  it("extracts bare uppercase tickers", async () => {
+    const { extractTickers } = await import("../client.js");
+    const result = extractTickers("Check out NVDA and MSFT today");
+    expect(result).toContain("NVDA");
+    expect(result).toContain("MSFT");
+  });
+
+  it("ignores stop words", async () => {
+    const { extractTickers } = await import("../client.js");
+    const result = extractTickers("THE CEO OF SEC SAID ALL ETF ARE GOOD FOR USA");
+    expect(result).toEqual([]);
+  });
+
+  it("handles empty and no-match text", async () => {
+    const { extractTickers } = await import("../client.js");
+    expect(extractTickers("")).toEqual([]);
+    expect(extractTickers("no tickers here at all")).toEqual([]);
+  });
+
+  it("deduplicates tickers from cashtag and bare word", async () => {
+    const { extractTickers } = await import("../client.js");
+    const result = extractTickers("$AAPL is great, AAPL to the moon");
+    expect(result).toEqual(["AAPL"]);
+  });
+});
+
+// ── scoreSentiment ───────────────────────────────────────────────────────────
+
+describe("scoreSentiment", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("scores bullish text positively", async () => {
+    const { scoreSentiment } = await import("../client.js");
+    expect(scoreSentiment("buying calls, moon rocket tendies!")).toBeGreaterThan(0);
+  });
+
+  it("scores bearish text negatively", async () => {
+    const { scoreSentiment } = await import("../client.js");
+    expect(scoreSentiment("selling puts, crash dump worthless")).toBeLessThan(0);
+  });
+
+  it("scores neutral text as zero", async () => {
+    const { scoreSentiment } = await import("../client.js");
+    expect(scoreSentiment("the stock traded sideways today")).toBe(0);
+  });
+});
+
+// ── fetchSubredditPosts ──────────────────────────────────────────────────────
+
+describe("fetchSubredditPosts", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal("fetch", vi.fn());
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("parses Reddit listing data correctly", async () => {
+    const listing = makeRedditListing([
+      { title: "AAPL is going up", selftext: "I bought calls", score: 42, num_comments: 10, subreddit: "stocks" },
+    ]);
+    mockFetchOk(listing);
+
+    const { fetchSubredditPosts } = await import("../client.js");
+    const posts = await fetchSubredditPosts("stocks", "AAPL", "week");
+
+    expect(posts).toHaveLength(1);
+    expect(posts[0].title).toBe("AAPL is going up");
+    expect(posts[0].selftext).toBe("I bought calls");
+    expect(posts[0].score).toBe(42);
+    expect(posts[0].numComments).toBe(10);
+    expect(posts[0].subreddit).toBe("stocks");
+    expect(posts[0]).toHaveProperty("createdUtc");
+    expect(posts[0]).toHaveProperty("permalink");
+  });
+
+  it("sends correct URL with encoded query", async () => {
+    mockFetchOk(makeRedditListing([]));
+
+    const { fetchSubredditPosts } = await import("../client.js");
+    await fetchSubredditPosts("wallstreetbets", "stocks OR market", "month", 10);
+
+    const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(calledUrl).toContain("/r/wallstreetbets/search.json");
+    expect(calledUrl).toContain("q=stocks%20OR%20market");
+    expect(calledUrl).toContain("t=month");
+    expect(calledUrl).toContain("limit=10");
+    expect(calledUrl).toContain("restrict_sr=on");
+    expect(calledUrl).toContain("sort=new");
+  });
+
+  it("sends User-Agent header", async () => {
+    mockFetchOk(makeRedditListing([]));
+
+    const { fetchSubredditPosts } = await import("../client.js");
+    await fetchSubredditPosts("stocks", "AAPL", "week");
+
+    const callArgs = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const headers = callArgs[1].headers;
+    expect(headers["User-Agent"]).toContain("stock-scanner-mcp");
+  });
+});
+
+// ── getTrendingTickers ───────────────────────────────────────────────────────
+
+describe("getTrendingTickers", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal("fetch", vi.fn());
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("aggregates tickers from multiple subreddits and caches", async () => {
+    const listing1 = makeRedditListing([
+      { title: "$AAPL calls printing", subreddit: "wallstreetbets" },
+      { title: "NVDA breakout incoming", subreddit: "wallstreetbets" },
+    ]);
+    const listing2 = makeRedditListing([
+      { title: "$AAPL earnings report", subreddit: "stocks" },
+    ]);
+
+    mockFetchOk(listing1);
+    mockFetchOk(listing2);
+
+    const { getTrendingTickers } = await import("../client.js");
+    const result = await getTrendingTickers(["wallstreetbets", "stocks"]);
+
+    expect(result.length).toBeGreaterThanOrEqual(1);
+    const aapl = result.find((t) => t.symbol === "AAPL");
+    expect(aapl).toBeDefined();
+    expect(aapl!.mentions).toBeGreaterThanOrEqual(2);
+    expect(aapl!.subreddits).toHaveProperty("wallstreetbets");
+    expect(aapl!.subreddits).toHaveProperty("stocks");
+
+    // Result is sorted by mentions descending
+    for (let i = 1; i < result.length; i++) {
+      expect(result[i - 1].mentions).toBeGreaterThanOrEqual(result[i].mentions);
+    }
+
+    // Second call should use cache (no more fetch calls)
+    const result2 = await getTrendingTickers(["wallstreetbets", "stocks"]);
+    expect(result2).toEqual(result);
+    expect(fetch).toHaveBeenCalledTimes(2); // only the initial 2 subreddit fetches
+  });
+});
+
+// ── getTickerMentions ────────────────────────────────────────────────────────
+
+describe("getTickerMentions", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal("fetch", vi.fn());
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns correct mention shape with subreddit breakdown", async () => {
+    // 4 subreddits = 4 fetch calls
+    for (let i = 0; i < 4; i++) {
+      mockFetchOk(makeRedditListing([
+        { title: "AAPL discussion", score: 100 - i * 10, subreddit: ["wallstreetbets", "stocks", "investing", "options"][i] },
+      ]));
+    }
+
+    const { getTickerMentions } = await import("../client.js");
+    const result = await getTickerMentions("AAPL");
+
+    expect(result.symbol).toBe("AAPL");
+    expect(result.totalMentions).toBe(4);
+    expect(Object.keys(result.subreddits)).toHaveLength(4);
+    expect(result.topPosts.length).toBeLessThanOrEqual(10);
+    // topPosts sorted by score descending
+    expect(result.topPosts[0].score).toBeGreaterThanOrEqual(result.topPosts[result.topPosts.length - 1].score);
+  });
+});
+
+// ── getTickerSentiment ───────────────────────────────────────────────────────
+
+describe("getTickerSentiment", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal("fetch", vi.fn());
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns sentiment breakdown with correct counts", async () => {
+    const bullishPost = { title: "AAPL buying calls moon rocket tendies", selftext: "diamond hands" };
+    const bearishPost = { title: "AAPL crash dump sell puts", selftext: "overvalued" };
+    const neutralPost = { title: "AAPL earnings report tomorrow", selftext: "" };
+
+    // wallstreetbets
+    mockFetchOk(makeRedditListing([bullishPost, bearishPost]));
+    // stocks
+    mockFetchOk(makeRedditListing([neutralPost]));
+    // investing
+    mockFetchOk(makeRedditListing([]));
+    // options
+    mockFetchOk(makeRedditListing([]));
+
+    const { getTickerSentiment } = await import("../client.js");
+    const result = await getTickerSentiment("AAPL");
+
+    expect(result.symbol).toBe("AAPL");
+    expect(result.bullishCount).toBe(1);
+    expect(result.bearishCount).toBe(1);
+    expect(result.neutralCount).toBe(1);
+    expect(typeof result.averageScore).toBe("number");
+    expect(result.samplePosts.length).toBeLessThanOrEqual(10);
+    expect(result.samplePosts[0]).toHaveProperty("sentimentScore");
+  });
+});

--- a/src/modules/reddit/__tests__/client.test.ts
+++ b/src/modules/reddit/__tests__/client.test.ts
@@ -268,3 +268,26 @@ describe("getTickerSentiment", () => {
     expect(result.samplePosts[0]).toHaveProperty("sentimentScore");
   });
 });
+
+// ── createRedditModule ───────────────────────────────────────────────────────
+
+describe("createRedditModule", () => {
+  it("returns module with 3 tools and no required env vars", async () => {
+    vi.resetModules();
+    const { createRedditModule } = await import("../index.js");
+    const mod = createRedditModule();
+    expect(mod.name).toBe("reddit");
+    expect(mod.requiredEnvVars).toEqual([]);
+    expect(mod.tools).toHaveLength(3);
+    expect(mod.tools.map((t) => t.name)).toEqual(["reddit_trending", "reddit_mentions", "reddit_sentiment"]);
+  });
+
+  it("all tools have readOnly: true", async () => {
+    vi.resetModules();
+    const { createRedditModule } = await import("../index.js");
+    const mod = createRedditModule();
+    for (const tool of mod.tools) {
+      expect(tool.readOnly).toBe(true);
+    }
+  });
+});

--- a/src/modules/reddit/client.ts
+++ b/src/modules/reddit/client.ts
@@ -1,0 +1,346 @@
+import { httpGet } from "../../shared/http.js";
+import { TtlCache } from "../../shared/cache.js";
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+export const REDDIT_BASE = "https://www.reddit.com";
+
+export const REDDIT_HEADERS: Record<string, string> = {
+  "User-Agent": "stock-scanner-mcp/1.0 (by /u/stock-scanner-bot)",
+};
+
+export const DEFAULT_SUBREDDITS = [
+  "wallstreetbets",
+  "stocks",
+  "investing",
+  "options",
+] as const;
+
+// 5-minute TTL for trending tickers
+export const trendingCache = new TtlCache<TrendingTicker[]>(5 * 60 * 1000);
+// 2-minute TTL for mention/sentiment queries
+export const mentionCache = new TtlCache<unknown>(2 * 60 * 1000);
+
+// ── Stop words ───────────────────────────────────────────────────────────────
+
+/** Common English words and finance acronyms that are NOT stock tickers */
+export const STOP_WORDS = new Set([
+  // 1-2 letter
+  "I", "A", "AM", "AN", "AS", "AT", "BE", "BY", "DO", "GO", "HE", "IF",
+  "IN", "IS", "IT", "ME", "MY", "NO", "OF", "OK", "ON", "OR", "SO", "TO",
+  "UP", "US", "WE",
+  // 3 letter common English
+  "ALL", "AND", "ANY", "ARE", "BAD", "BIG", "BUT", "CAN", "DAY", "DID",
+  "END", "FAR", "FEW", "FOR", "GET", "GOD", "GOT", "GUY", "HAS", "HAD",
+  "HER", "HIM", "HIS", "HOW", "ITS", "JOB", "LET", "LOT", "MAN", "MAY",
+  "MEN", "MOM", "NEW", "NOT", "NOW", "OLD", "ONE", "OUR", "OUT", "OWN",
+  "PUT", "RAN", "RUN", "SAT", "SAY", "SET", "SHE", "SIT", "THE", "TOO",
+  "TOP", "TRY", "TWO", "USE", "WAR", "WAS", "WAY", "WHO", "WHY", "WIN",
+  "WON", "YES", "YET", "YOU",
+  // 4 letter common English
+  "ALSO", "BACK", "BEEN", "BEST", "BODY", "BOTH", "CALL", "CAME", "COME",
+  "DARK", "DAYS", "DEAD", "DOES", "DONE", "DOWN", "EACH", "EVEN", "EVER",
+  "EYES", "FACE", "FACT", "FEEL", "FIND", "FOUR", "FROM", "FULL", "GAVE",
+  "GIVE", "GOOD", "HALF", "HAND", "HARD", "HAVE", "HEAD", "HEAR", "HELP",
+  "HERE", "HIGH", "HOME", "HOPE", "IDEA", "INTO", "JUST", "KEEP", "KIND",
+  "KNEW", "KNOW", "LAND", "LAST", "LEFT", "LESS", "LIFE", "LIKE", "LINE",
+  "LIST", "LIVE", "LONG", "LOOK", "LOST", "LOVE", "MADE", "MAKE", "MANY",
+  "MIND", "MORE", "MOST", "MUCH", "MUST", "NAME", "NEED", "NEWS", "NEXT",
+  "NICE", "NONE", "ONCE", "ONLY", "OPEN", "OVER", "PAID", "PART", "PAST",
+  "PLAN", "PLAY", "POST", "PULL", "PUSH", "RATE", "READ", "REAL", "REST",
+  "RISK", "ROOM", "SAFE", "SAID", "SAME", "SEEN", "SHOW", "SIDE", "SOME",
+  "SOON", "STOP", "SUCH", "SURE", "TAKE", "TALK", "TELL", "THAN", "THAT",
+  "THEM", "THEN", "THEY", "THIS", "TIME", "TOOK", "TRUE", "TURN", "UPON",
+  "VERY", "WANT", "WEEK", "WELL", "WENT", "WERE", "WHAT", "WHEN", "WILL",
+  "WITH", "WORD", "WORK", "YEAR", "YOUR",
+  // 5 letter common English
+  "ABOUT", "AFTER", "AGAIN", "BEING", "BELOW", "BLACK", "BRING", "COULD",
+  "EARLY", "EVERY", "FIRST", "GREAT", "GREEN", "HEARD", "HOUSE", "LARGE",
+  "LATER", "LEARN", "LEVEL", "LIGHT", "MIGHT", "MONEY", "MONTH", "NEVER",
+  "NIGHT", "OTHER", "PLACE", "POINT", "POWER", "PRICE", "RIGHT", "SHALL",
+  "SINCE", "SMALL", "SORRY", "STAND", "START", "STATE", "STILL", "STUDY",
+  "THEIR", "THERE", "THESE", "THING", "THINK", "THREE", "TODAY", "UNDER",
+  "UNTIL", "WATER", "WHERE", "WHICH", "WHITE", "WHILE", "WHOLE", "WORLD",
+  "WOULD", "WRITE", "YOUNG",
+  // Finance acronyms that aren't tickers
+  "ETF", "IPO", "SEC", "GDP", "FDA", "FED", "CEO", "CFO", "COO", "CTO",
+  "ATH", "ATL", "EOD", "WSB", "OTC", "ITM", "OTM", "IMO", "LOL", "OMG",
+  "USA", "NYSE", "YOLO", "FOMO", "HODL", "MOASS", "TLDR", "IMHO", "LMAO",
+  "EDIT", "TLDR", "INFO", "HUGE", "GAIN", "HOLD", "SELL", "MOON",
+  "CASH", "DEBT", "FUND", "BEAR", "BULL", "BOND", "LOAN", "LOSS",
+  "PUMP", "DUMP", "LONG", "MAMA", "PAPA", "FREE", "ZERO", "PLUS",
+]);
+
+// ── Ticker extraction ────────────────────────────────────────────────────────
+
+const CASHTAG_RE = /\$([A-Z]{2,5})\b/g;
+const BARE_TICKER_RE = /\b([A-Z]{2,5})\b/g;
+
+/**
+ * Extract stock tickers from text using cashtag patterns and bare uppercase words.
+ * Filters out common English words and finance acronyms.
+ */
+export function extractTickers(text: string): string[] {
+  const tickers = new Set<string>();
+
+  // 1. Cashtag matches (high confidence)
+  let match: RegExpExecArray | null;
+  CASHTAG_RE.lastIndex = 0;
+  while ((match = CASHTAG_RE.exec(text)) !== null) {
+    const ticker = match[1];
+    if (!STOP_WORDS.has(ticker)) {
+      tickers.add(ticker);
+    }
+  }
+
+  // 2. Bare uppercase words (lower confidence, filtered by stop words)
+  BARE_TICKER_RE.lastIndex = 0;
+  while ((match = BARE_TICKER_RE.exec(text)) !== null) {
+    const word = match[1];
+    if (!STOP_WORDS.has(word)) {
+      tickers.add(word);
+    }
+  }
+
+  return [...tickers];
+}
+
+// ── Sentiment scoring ────────────────────────────────────────────────────────
+
+const BULLISH_TERMS = [
+  "bull", "calls", "long", "moon", "rocket", "tendies", "diamond hands",
+  "buy", "buying", "bought", "dip", "undervalued", "breakout", "squeeze",
+  "gamma", "rip", "printing", "lambo", "gains", "green", "upside",
+];
+
+const BEARISH_TERMS = [
+  "bear", "puts", "short", "dump", "crash", "sell", "selling", "sold",
+  "overvalued", "bubble", "bag", "bagholder", "red", "loss", "losses",
+  "downside", "drill", "tank", "fade", "rug", "rekt", "worthless",
+];
+
+/**
+ * Score text sentiment using keyword matching.
+ * Returns positive for bullish, negative for bearish, 0 for neutral.
+ */
+export function scoreSentiment(text: string): number {
+  const lower = text.toLowerCase();
+  let score = 0;
+
+  for (const term of BULLISH_TERMS) {
+    if (lower.includes(term)) score += 1;
+  }
+  for (const term of BEARISH_TERMS) {
+    if (lower.includes(term)) score -= 1;
+  }
+
+  return score;
+}
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface RedditPost {
+  title: string;
+  selftext: string;
+  score: number;
+  numComments: number;
+  createdUtc: number;
+  permalink: string;
+  subreddit: string;
+}
+
+interface RedditListingChild {
+  data: {
+    title: string;
+    selftext: string;
+    score: number;
+    num_comments: number;
+    created_utc: number;
+    permalink: string;
+    subreddit: string;
+  };
+}
+
+interface RedditListing {
+  data: {
+    children: RedditListingChild[];
+  };
+}
+
+export interface TrendingTicker {
+  symbol: string;
+  mentions: number;
+  subreddits: Record<string, number>;
+}
+
+export interface TickerMentionResult {
+  symbol: string;
+  totalMentions: number;
+  subreddits: Record<string, number>;
+  topPosts: RedditPost[];
+}
+
+export interface TickerSentimentResult {
+  symbol: string;
+  bullishCount: number;
+  bearishCount: number;
+  neutralCount: number;
+  averageScore: number;
+  samplePosts: Array<RedditPost & { sentimentScore: number }>;
+}
+
+// ── Reddit API client ────────────────────────────────────────────────────────
+
+export async function fetchSubredditPosts(
+  subreddit: string,
+  query: string,
+  timeFilter: string,
+  limit = 25,
+): Promise<RedditPost[]> {
+  const url = `${REDDIT_BASE}/r/${encodeURIComponent(subreddit)}/search.json?q=${encodeURIComponent(query)}&sort=new&restrict_sr=on&t=${encodeURIComponent(timeFilter)}&limit=${encodeURIComponent(String(limit))}`;
+
+  const listing = await httpGet<RedditListing>(url, {
+    headers: REDDIT_HEADERS,
+  });
+
+  return listing.data.children.map((child) => ({
+    title: child.data.title,
+    selftext: child.data.selftext,
+    score: child.data.score,
+    numComments: child.data.num_comments,
+    createdUtc: child.data.created_utc,
+    permalink: child.data.permalink,
+    subreddit: child.data.subreddit,
+  }));
+}
+
+// ── High-level functions ─────────────────────────────────────────────────────
+
+export async function getTrendingTickers(
+  subreddits: readonly string[] = DEFAULT_SUBREDDITS,
+  limit = 20,
+): Promise<TrendingTicker[]> {
+  const cacheKey = `trending:${[...subreddits].sort().join(",")}:${limit}`;
+  const cached = trendingCache.get(cacheKey);
+  if (cached) return cached;
+
+  const tickerMap = new Map<string, { mentions: number; subreddits: Record<string, number> }>();
+
+  for (const sub of subreddits) {
+    let posts: RedditPost[];
+    try {
+      posts = await fetchSubredditPosts(sub, "stocks OR market OR trading", "week");
+    } catch {
+      continue;
+    }
+
+    for (const post of posts) {
+      const text = `${post.title} ${post.selftext}`;
+      const tickers = extractTickers(text);
+      for (const ticker of tickers) {
+        const existing = tickerMap.get(ticker) ?? { mentions: 0, subreddits: {} };
+        existing.mentions += 1;
+        existing.subreddits[sub] = (existing.subreddits[sub] ?? 0) + 1;
+        tickerMap.set(ticker, existing);
+      }
+    }
+  }
+
+  const result: TrendingTicker[] = [...tickerMap.entries()]
+    .map(([symbol, data]) => ({ symbol, mentions: data.mentions, subreddits: data.subreddits }))
+    .sort((a, b) => b.mentions - a.mentions)
+    .slice(0, limit);
+
+  trendingCache.set(cacheKey, result);
+  return result;
+}
+
+export async function getTickerMentions(
+  symbol: string,
+  period = "week",
+): Promise<TickerMentionResult> {
+  const cacheKey = `mentions:${symbol}:${period}`;
+  const cached = mentionCache.get(cacheKey);
+  if (cached) return cached as TickerMentionResult;
+
+  const subredditCounts: Record<string, number> = {};
+  const allPosts: RedditPost[] = [];
+
+  for (const sub of DEFAULT_SUBREDDITS) {
+    let posts: RedditPost[];
+    try {
+      posts = await fetchSubredditPosts(sub, symbol, period);
+    } catch {
+      continue;
+    }
+
+    subredditCounts[sub] = posts.length;
+    allPosts.push(...posts);
+  }
+
+  const topPosts = allPosts
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 10);
+
+  const result: TickerMentionResult = {
+    symbol,
+    totalMentions: allPosts.length,
+    subreddits: subredditCounts,
+    topPosts,
+  };
+
+  mentionCache.set(cacheKey, result);
+  return result;
+}
+
+export async function getTickerSentiment(
+  symbol: string,
+  limit = 50,
+): Promise<TickerSentimentResult> {
+  const cacheKey = `sentiment:${symbol}:${limit}`;
+  const cached = mentionCache.get(cacheKey);
+  if (cached) return cached as TickerSentimentResult;
+
+  const allPosts: RedditPost[] = [];
+
+  for (const sub of DEFAULT_SUBREDDITS) {
+    let posts: RedditPost[];
+    try {
+      posts = await fetchSubredditPosts(sub, symbol, "week", limit);
+    } catch {
+      continue;
+    }
+    allPosts.push(...posts);
+  }
+
+  let bullishCount = 0;
+  let bearishCount = 0;
+  let neutralCount = 0;
+  let totalScore = 0;
+
+  const scored = allPosts.map((post) => {
+    const text = `${post.title} ${post.selftext}`;
+    const sentimentScore = scoreSentiment(text);
+    totalScore += sentimentScore;
+    if (sentimentScore > 0) bullishCount += 1;
+    else if (sentimentScore < 0) bearishCount += 1;
+    else neutralCount += 1;
+    return { ...post, sentimentScore };
+  });
+
+  const samplePosts = scored
+    .sort((a, b) => Math.abs(b.sentimentScore) - Math.abs(a.sentimentScore))
+    .slice(0, 10);
+
+  const result: TickerSentimentResult = {
+    symbol,
+    bullishCount,
+    bearishCount,
+    neutralCount,
+    averageScore: allPosts.length > 0 ? totalScore / allPosts.length : 0,
+    samplePosts,
+  };
+
+  mentionCache.set(cacheKey, result);
+  return result;
+}

--- a/src/modules/reddit/index.ts
+++ b/src/modules/reddit/index.ts
@@ -1,0 +1,75 @@
+import { z } from "zod";
+import type { ModuleDefinition } from "../../shared/types.js";
+import { successResult } from "../../shared/types.js";
+import { getTrendingTickers, getTickerMentions, getTickerSentiment } from "./client.js";
+import { withMetadata } from "../../shared/utils.js";
+
+const trendingTool = {
+  name: "reddit_trending",
+  description:
+    "Get trending stock tickers from Reddit based on mention frequency. " +
+    "Scans r/wallstreetbets, r/stocks, r/investing, and r/options for posts mentioning tickers. " +
+    "Returns tickers sorted by mention count with per-subreddit breakdown. " +
+    "Limitation: uses keyword extraction (cashtags + uppercase words), not NLP — " +
+    "some false positives possible. Best for gauging retail buzz, not precise sentiment.",
+  inputSchema: z.object({
+    subreddits: z.array(z.string()).optional()
+      .describe("Subreddits to scan (default: wallstreetbets, stocks, investing, options)"),
+    limit: z.number().default(20)
+      .describe("Maximum number of trending tickers to return (default: 20)"),
+  }),
+  readOnly: true,
+  handler: withMetadata(async (args: { subreddits?: string[]; limit?: number }) => {
+    const result = await getTrendingTickers(args.subreddits, args.limit ?? 20);
+    return successResult(JSON.stringify(result, null, 2));
+  }, { source: "reddit", dataDelay: "real-time" }),
+};
+
+const mentionsTool = {
+  name: "reddit_mentions",
+  description:
+    "Get mention count and top posts for a specific stock ticker across Reddit. " +
+    "Searches r/wallstreetbets, r/stocks, r/investing, and r/options. " +
+    "Returns total mentions, per-subreddit breakdown, and top 10 posts by score. " +
+    "Use this to check how much retail attention a ticker is getting.",
+  inputSchema: z.object({
+    symbol: z.string().describe("Stock ticker symbol (e.g. AAPL, TSLA, GME)"),
+    period: z.enum(["hour", "day", "week"]).default("day")
+      .describe("Time period to search (default: day)"),
+  }),
+  readOnly: true,
+  handler: withMetadata(async (args: { symbol: string; period?: string }) => {
+    const result = await getTickerMentions(args.symbol, args.period ?? "day");
+    return successResult(JSON.stringify(result, null, 2));
+  }, { source: "reddit", dataDelay: "real-time" }),
+};
+
+const sentimentTool = {
+  name: "reddit_sentiment",
+  description:
+    "Get sentiment analysis for a stock ticker from Reddit discussions. " +
+    "Searches r/wallstreetbets, r/stocks, r/investing, and r/options, then scores each post " +
+    "using keyword matching (bullish terms like 'moon', 'calls', 'breakout' vs " +
+    "bearish terms like 'crash', 'puts', 'dump'). " +
+    "Returns bullish/bearish/neutral counts, average sentiment score, and sample posts. " +
+    "Limitation: keyword-based scoring, not NLP — sarcasm and context may be missed.",
+  inputSchema: z.object({
+    symbol: z.string().describe("Stock ticker symbol (e.g. AAPL, TSLA, GME)"),
+    limit: z.number().default(50)
+      .describe("Maximum posts to analyze per subreddit (default: 50)"),
+  }),
+  readOnly: true,
+  handler: withMetadata(async (args: { symbol: string; limit?: number }) => {
+    const result = await getTickerSentiment(args.symbol, args.limit ?? 50);
+    return successResult(JSON.stringify(result, null, 2));
+  }, { source: "reddit", dataDelay: "real-time" }),
+};
+
+export function createRedditModule(): ModuleDefinition {
+  return {
+    name: "reddit",
+    description: "Reddit sentiment — trending tickers, mention tracking, and sentiment analysis from popular investing subreddits",
+    requiredEnvVars: [],
+    tools: [trendingTool, mentionsTool, sentimentTool],
+  };
+}

--- a/src/modules/reddit/index.ts
+++ b/src/modules/reddit/index.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { ModuleDefinition } from "../../shared/types.js";
 import { successResult } from "../../shared/types.js";
-import { getTrendingTickers, getTickerMentions, getTickerSentiment } from "./client.js";
+import { getTrendingTickers, getTickerMentions, getTickerSentiment, DEFAULT_SUBREDDITS } from "./client.js";
 import { withMetadata } from "../../shared/utils.js";
 
 const trendingTool = {
@@ -13,14 +13,14 @@ const trendingTool = {
     "Limitation: uses keyword extraction (cashtags + uppercase words), not NLP — " +
     "some false positives possible. Best for gauging retail buzz, not precise sentiment.",
   inputSchema: z.object({
-    subreddits: z.array(z.string()).optional()
+    subreddits: z.array(z.string()).max(10).optional()
       .describe("Subreddits to scan (default: wallstreetbets, stocks, investing, options)"),
-    limit: z.number().default(20)
+    limit: z.number().min(1).max(50).default(20)
       .describe("Maximum number of trending tickers to return (default: 20)"),
   }),
   readOnly: true,
   handler: withMetadata(async (args: { subreddits?: string[]; limit?: number }) => {
-    const result = await getTrendingTickers(args.subreddits, args.limit ?? 20);
+    const result = await getTrendingTickers(args.subreddits ?? [...DEFAULT_SUBREDDITS], args.limit ?? 20);
     return successResult(JSON.stringify(result, null, 2));
   }, { source: "reddit", dataDelay: "real-time" }),
 };
@@ -33,13 +33,13 @@ const mentionsTool = {
     "Returns total mentions, per-subreddit breakdown, and top 10 posts by score. " +
     "Use this to check how much retail attention a ticker is getting.",
   inputSchema: z.object({
-    symbol: z.string().describe("Stock ticker symbol (e.g. AAPL, TSLA, GME)"),
+    symbol: z.string().max(10).describe("Stock ticker symbol (e.g. AAPL, TSLA, GME)"),
     period: z.enum(["hour", "day", "week"]).default("day")
       .describe("Time period to search (default: day)"),
   }),
   readOnly: true,
   handler: withMetadata(async (args: { symbol: string; period?: string }) => {
-    const result = await getTickerMentions(args.symbol, args.period ?? "day");
+    const result = await getTickerMentions(args.symbol.toUpperCase(), args.period ?? "day");
     return successResult(JSON.stringify(result, null, 2));
   }, { source: "reddit", dataDelay: "real-time" }),
 };
@@ -54,13 +54,13 @@ const sentimentTool = {
     "Returns bullish/bearish/neutral counts, average sentiment score, and sample posts. " +
     "Limitation: keyword-based scoring, not NLP — sarcasm and context may be missed.",
   inputSchema: z.object({
-    symbol: z.string().describe("Stock ticker symbol (e.g. AAPL, TSLA, GME)"),
-    limit: z.number().default(50)
+    symbol: z.string().max(10).describe("Stock ticker symbol (e.g. AAPL, TSLA, GME)"),
+    limit: z.number().min(1).max(100).default(50)
       .describe("Maximum posts to analyze per subreddit (default: 50)"),
   }),
   readOnly: true,
   handler: withMetadata(async (args: { symbol: string; limit?: number }) => {
-    const result = await getTickerSentiment(args.symbol, args.limit ?? 50);
+    const result = await getTickerSentiment(args.symbol.toUpperCase(), args.limit ?? 50);
     return successResult(JSON.stringify(result, null, 2));
   }, { source: "reddit", dataDelay: "real-time" }),
 };

--- a/src/scripts/validate-tools.ts
+++ b/src/scripts/validate-tools.ts
@@ -24,6 +24,7 @@ import { createOptionsCboeModule } from "../modules/options-cboe/index.js";
 import { createFredModule } from "../modules/fred/index.js";
 import { createSentimentModule } from "../modules/sentiment/index.js";
 import { createFrankfurterModule } from "../modules/frankfurter/index.js";
+import { createRedditModule } from "../modules/reddit/index.js";
 import type { ModuleDefinition, ToolDefinition } from "../shared/types.js";
 
 // ── Constants ────────────────────────────────────────────────────────
@@ -42,6 +43,7 @@ const MODULE_PREFIX_MAP: Record<string, string[]> = {
   fred: ["fred_"],
   sentiment: ["sentiment_"],
   frankfurter: ["frankfurter_"],
+  reddit: ["reddit_"],
 };
 
 const DATA_SOURCE_KEYWORDS: Record<string, string[]> = {
@@ -56,6 +58,7 @@ const DATA_SOURCE_KEYWORDS: Record<string, string[]> = {
   fred: ["fred", "economic", "federal reserve"],
   sentiment: ["sentiment", "fear", "greed", "cnn", "alternative"],
   frankfurter: ["frankfurter", "forex", "exchange rate", "ecb", "currency"],
+  reddit: ["reddit", "subreddit", "r/wallstreetbets", "r/stocks"],
 };
 
 // ── Types ────────────────────────────────────────────────────────────
@@ -243,6 +246,7 @@ function buildAllModules(): ModuleDefinition[] {
     createFredModule("mock-key"),
     createSentimentModule(),
     createFrankfurterModule(),
+    createRedditModule(),
   ];
 }
 


### PR DESCRIPTION
## Summary

Adds a new `reddit` module with 3 tools providing social sentiment data from Reddit finance subreddits. No API key required — auto-enabled.

### New tools
- **`reddit_trending`** — Top mentioned tickers across r/wallstreetbets, r/stocks, r/investing, r/options
- **`reddit_mentions`** — Mention count + top posts for a specific ticker with subreddit breakdown
- **`reddit_sentiment`** — Bullish/bearish/neutral keyword-based sentiment scoring

### Technical details
- Reddit public JSON API (no auth needed)
- Keyword-based sentiment (21 bullish + 22 bearish terms, WSB-specific)
- Ticker extraction via cashtag + bare uppercase with comprehensive stop-word filtering
- Caching: 5min for trending, 2min for mentions/sentiment
- 16 new tests (399 total), all passing

### Quality gates
- [x] `npm run lint` — clean
- [x] `npm test` — 399 tests passing
- [x] `npm run validate-tools` — 57 tools validated
- [x] `npm run build` — clean

Closes #195