### PR TITLE
ci: add Claude Code GitHub Action (@claude on issues & PRs)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,47 @@
+name: Claude Code
+
+# Responds when you mention @claude in an issue, an issue comment,
+# a PR comment, or a PR review. Claude can answer questions, implement
+# small changes and push a branch/PR, or review code — all following
+# the rules in CLAUDE.md.
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  claude:
+    # Only spin up a runner when "@claude" actually appears, so we don't
+    # burn Actions minutes (or usage credits) on every comment.
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write        # let Claude push branches / commits
+      pull-requests: write    # open and comment on PRs
+      issues: write           # comment on issues
+      actions: read           # read CI results on PRs
+      id-token: write         # short-lived auth for the action
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          # Uses your Max subscription via an OAuth token (no API key).
+          # Add the token under Settings -> Secrets and variables -> Actions.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Keep automation runs bounded so a single task can't run away.
+          claude_args: |
+            --max-turns 15


### PR DESCRIPTION
## What

Adds `.github/workflows/claude.yml` so you can mention `@claude` in a new issue, an issue comment, a PR comment, or a PR review. Claude will answer, implement small changes (pushing a branch/PR), or review code — following `CLAUDE.md`.

## Auth

Uses the **Max-plan OAuth token** (`CLAUDE_CODE_OAUTH_TOKEN` secret), not an API key. With the account's *Usage Credits* toggle off, it hard-stops at the limit instead of charging overage.

## Safety

- Job only starts when `@claude` is actually present (saves Actions minutes / credits).
- Runs capped at `--max-turns 15`.
- Untrusted inputs are only used inside `if:` `contains()` expressions — never interpolated into a shell, so no command-injection path.

## Before this works (manual setup)

1. Install the Claude GitHub App: https://github.com/apps/claude
2. `claude setup-token` -> add output as repo secret `CLAUDE_CODE_OAUTH_TOKEN`

## Test after merge

Open an issue and comment `@claude summarize what this repo does`.