### PR TITLE
ci: temporarily show full output on Claude action (debug)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -42,6 +42,9 @@ jobs:
           # Uses your Max subscription via an OAuth token (no API key).
           # Add the token under Settings -> Secrets and variables -> Actions.
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Temporary: surface the full model output so we can read the real
+          # error while debugging setup. Remove once @claude works end to end.
+          show_full_output: true
           # Keep automation runs bounded so a single task can't run away.
           claude_args: |
             --max-turns 15


### PR DESCRIPTION
The `@claude` job fails on turn 1 at $0 cost — the request is rejected before any generation, and the action hides the real API error by default. This adds `show_full_output: true` so we can read the actual error. Will revert once auth works.