### PR TITLE
ci: remove temporary show_full_output from Claude action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -42,9 +42,6 @@ jobs:
           # Uses your Max subscription via an OAuth token (no API key).
           # Add the token under Settings -> Secrets and variables -> Actions.
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # Temporary: surface the full model output so we can read the real
-          # error while debugging setup. Remove once @claude works end to end.
-          show_full_output: true
           # Keep automation runs bounded so a single task can't run away.
           claude_args: |
             --max-turns 15


### PR DESCRIPTION
Debugging done — the `@claude` failure was `401 Invalid bearer token` (bad OAuth secret), not a logging gap. Removing the verbose flag so the workflow no longer echoes the model transcript into CI logs (flagged by automated security review as a prompt-injection exfiltration risk). Reverts the temporary change from #215.