### PR TITLE
fix: enable workspace in plugin + correct plugin install docs

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "stock-scanner": {
       "command": "npx",
-      "args": ["-y", "stock-scanner-mcp"],
+      "args": ["-y", "stock-scanner-mcp", "--enable-workspace"],
       "env": {
         "FINNHUB_API_KEY": "${FINNHUB_API_KEY}",
         "ALPHA_VANTAGE_API_KEY": "${ALPHA_VANTAGE_API_KEY}",

--- a/README.md
+++ b/README.md
@@ -52,14 +52,18 @@ This gives you **46 tools** immediately with no API keys. API keys are optional 
 
 Restart Claude Desktop after saving. Claude Code picks up the config automatically.
 
-> **Claude Code shortcut — install as a plugin instead of Step 1.** If you use Claude Code, you can skip the manual config above and install the server with two commands:
+> **Claude Code shortcut — install as a plugin instead of Steps 1 and 2.** If you use Claude Code, skip the manual config above and install everything with two commands:
 > ```
 > /plugin marketplace add yyordanov-tradu/stock-scanner-mcp
 > /plugin install stock-scanner@tradu-marketplace
 > ```
-> Then run `/mcp` — you should see the `stock-scanner` server listed as connected. The plugin launches the server via `npx -y stock-scanner-mcp`, so the first launch downloads the package once (then it is cached). Optional API keys (`FINNHUB_API_KEY`, `ALPHA_VANTAGE_API_KEY`, `FRED_API_KEY`) are passed through from your environment; modules without a key are skipped automatically. Steps 2 and 3 below still apply.
+> Run `/reload-plugins`, then `/mcp` — you should see the `stock-scanner` server listed as connected. The first launch runs `npx -y stock-scanner-mcp`, which downloads the package once (then it is cached). The plugin enables the workspace by default (data is stored in `~/.stock-scanner-mcp`) and passes the optional API keys (`FINNHUB_API_KEY`, `ALPHA_VANTAGE_API_KEY`, `FRED_API_KEY`) through from your environment; modules without a key are skipped automatically.
+>
+> **The plugin already bundles the skills — do NOT run Step 2.** All 19 skills ship with the plugin and load under the `stock-scanner:` namespace, e.g. `/stock-scanner:analyze-stock AAPL`, `/stock-scanner:morning-briefing`, `/stock-scanner:setup-market-workspace`. Running the Step 2 installer as well copies a second, unprefixed set into `~/.claude/skills/`, and the two collide — Step 2 is only for the manual (non-plugin) install. After installing, go straight to Step 3, using the namespaced command: `/stock-scanner:setup-market-workspace`.
 
 ### Step 2 — Install the trading skills
+
+> Skip this step if you installed via the plugin above — the plugin already bundles these skills (as `stock-scanner:<name>`). This step is only for the manual config in Step 1.
 
 Run this command in your terminal:
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -4,6 +4,8 @@ Ready-made trading workflows that orchestrate [stock-scanner-mcp](https://www.np
 
 ## Quick Start
 
+> **Installed the Claude Code plugin?** You already have these skills — the plugin bundles them and loads them under the `stock-scanner:` namespace (e.g. `/stock-scanner:morning-briefing`). Skip the installer below; it is only for the manual MCP-server setup.
+
 **Prerequisites:** stock-scanner-mcp configured as an MCP server in Claude Code.
 
 ```bash

--- a/src/__tests__/plugin-manifests.test.ts
+++ b/src/__tests__/plugin-manifests.test.ts
@@ -85,6 +85,10 @@ describe("plugin manifests", () => {
     expect(server.command).toBe("npx");
     expect(server.args).toContain("stock-scanner-mcp");
     expect(server.args).toContain("-y");
+    // Workspace must stay enabled so plugin users get the full tool set
+    // (workspace tools + /setup-market-workspace). Data dir defaults to
+    // ~/.stock-scanner-mcp, which is CWD-independent under npx.
+    expect(server.args).toContain("--enable-workspace");
     // Negative assertion: the rejected dist/-commit path must never come back.
     expect(server.args).not.toContain("${CLAUDE_PLUGIN_ROOT}/dist/index.js");
     expect(server.args.some((a) => a.includes("dist/index.js"))).toBe(false);


### PR DESCRIPTION
## Why

Follow-up to #221. Testing the plugin install surfaced three gaps in how the plugin path works vs. how it was documented:

1. The README told plugin users *"Steps 2 and 3 still apply"* — but **Step 2** (`stock-scanner-install-skills`) is redundant for plugin users (the plugin bundles all 19 skills) and creates duplicate, differently-named skill copies.
2. Plugin skills load **namespaced** as `stock-scanner:<name>`; every doc referenced bare names (`/setup-market-workspace`, etc.), so a plugin user couldn't find them.
3. The plugin's `.mcp.json` ran `npx -y stock-scanner-mcp` with **no flags**, so the workspace was off (39 tools, not 46/65). **Step 3** (`/setup-market-workspace`) had no workspace tools to call.

## What changed

- **`.mcp.json`** — pass `--enable-workspace` so the plugin delivers the full experience. Data dir defaults to `~/.stock-scanner-mcp` (absolute, CWD-independent under npx — verified in `config.ts`/`registry.ts`).
- **`plugin-manifests.test.ts`** — assert `--enable-workspace` stays present so it can't be dropped silently.
- **`README.md`** — rewrite the plugin callout: skip Step 2, skills load as `stock-scanner:<name>`, workspace on by default; add a skip-note at Step 2.
- **`skills/README.md`** — note plugin users already have the skills bundled.

## Tests / gates

- `npm run lint` ✓
- `npm test` ✓ (424 passed, incl. new workspace assertion)
- `npm run validate-tools` ✓ (65 tools)
- `npm run build` ✓

## Verification still owed (Pass 2, from outside the repo)

After merge, install from main in a clean dir and confirm: `/mcp` shows the workspace tools (count 46/65), `/stock-scanner:setup-market-workspace` runs, and bundled skills appear as `stock-scanner:<name>`.