### PR TITLE
chore: release v1.17.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stock-scanner",
   "description": "Stock and crypto market data for Claude Code -- technical indicators, news, filings, fundamentals, and crypto metrics from free APIs",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "author": {
     "name": "Yordan Yordanov"
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-**Version:** 1.17.0 — Published on npm as `stock-scanner-mcp`
+**Version:** 1.17.1 — Published on npm as `stock-scanner-mcp`
 **Modules:** 13 implemented (65 tools total)
 
 Planning docs (historical): `docs/architecture.md`, `docs/plans/` — reference only, not actively maintained

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stock-scanner-mcp",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stock-scanner-mcp",
-      "version": "1.17.0",
+      "version": "1.17.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stock-scanner-mcp",
   "mcpName": "io.github.yyordanov-tradu/stock-scanner-mcp",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "description": "MCP server providing Claude Code with real-time stock and crypto market data, SEC filings, insider trades, and technical analysis",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release v1.17.1.

## Included since v1.17.0
- #221 — make installable as a Claude Code plugin via npx
- #225 — enable workspace in the plugin + correct plugin install docs

## Version lockstep
- `package.json` → 1.17.1
- `.claude-plugin/plugin.json` → 1.17.1
- `CLAUDE.md` → 1.17.1

Module/tool counts unchanged (13 modules, 65 tools). Tag `v1.17.1` pushed — CI publishes to npm.