### PR TITLE
ci: auto-merge low-risk Dependabot PRs after CI passes

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,31 @@
+name: Dependabot auto-merge
+
+# Auto-merge low-risk Dependabot PRs once all required CI checks pass.
+# Patch and minor bumps merge automatically; major bumps are left for a human
+# to review. Auto-merge waits for the branch protection rules on main, so a
+# PR only lands after CI (lint, test, validate-tools, build, security-scan) is green.
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    # Only act on PRs opened by Dependabot.
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch and minor updates
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Adds `.github/workflows/dependabot-auto-merge.yml` — enables GitHub auto-merge on Dependabot PRs for **patch** and **minor** version bumps. **Major** bumps are left for manual review (e.g. the current #224 @types/node 25→26 and #222 checkout 6→7 would still stop for a human).

## How it works

- Triggers on `pull_request`, only when the actor is `dependabot[bot]`.
- Reads the semver update-type via `dependabot/fetch-metadata@v2`.
- For patch/minor, calls `gh pr merge --auto --squash`, which **waits for required CI checks** before landing.

## Required repo setting (action needed)

Auto-merge must be allowed on the repo for the `--auto` flag to work. Currently `allow_auto_merge` is **false**. Enable it:
```
Settings → General → Pull Requests → ✅ Allow auto-merge
```
Without it, the workflow step errors (it won't merge anything unsafely — it just fails).

## Security

Follows the documented-safe pattern: PR URL passed via `env:` and quoted (`"$PR_URL"`), never interpolated into the run line. `contents/pull-requests: write` scoped to this workflow only.

## Notes

- Squash matches the repo's merge style (`allow_squash_merge: true`).
- For full safety this relies on branch protection requiring CI on main, so auto-merge gates on green checks.