### PR TITLE
ci: gate PRs on critical npm audit findings in prod deps

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -22,4 +22,6 @@ jobs:
       - run: npm ci
 
       - name: Audit dependencies
-        run: npm audit --omit=dev
+        # Match the PR gate: fail only on critical advisories in production
+        # deps. Lower severities are surfaced by Dependabot alerts instead.
+        run: npm audit --omit=dev --audit-level=critical

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,17 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      # Block a PR before merge if it introduces a critical-severity advisory
+      # in a shipped (production) dependency. Lower severities are caught in
+      # real time by Dependabot alerts, so we don't fail PRs on upstream noise.
+      - name: Audit production dependencies
+        run: npm audit --omit=dev --audit-level=critical
+
       - name: Check for hardcoded secrets
         run: |
           if grep -rn --include="*.ts" -E "(api[_-]?key|secret|token|password)\s*[:=]\s*['\"][A-Za-z0-9]{16,}" src/ | grep -v __tests__/ | grep -v ".example"; then


### PR DESCRIPTION
## What

- **`ci.yml`** — adds an `npm audit --omit=dev --audit-level=critical` step to the `security-scan` job. A PR is now blocked before merge if it introduces a **critical** advisory in a shipped (production) dependency.
- **`audit.yml`** — pins the weekly Security Audit job to the same `--audit-level=critical`.

## Why critical, not high

There are **3 existing high-severity advisories** (`path-to-regexp` x2, plus moderate `qs`) that come transitively from the MCP SDK:

```
@modelcontextprotocol/sdk@1.29.0 → express@5.2.1 → { path-to-regexp, qs }
```

They are **not cleanly fixable from this repo** (`npm audit fix` dry-run leaves them; a real fix needs the SDK to bump Express). Gating at `high` would turn CI red on main immediately and stay red until upstream updates. Gating at `critical`:

- Starts **green** (no criticals today).
- Blocks the genuinely severe stuff before merge.
- Leaves highs/moderates to **Dependabot alerts** (event-driven, enabled separately) — which also auto-open patch PRs when upstream ships a fix.

## Side fix

The weekly `audit.yml` previously ran `npm audit --omit=dev` with **no threshold**, so it exited non-zero on any advisory — meaning it was **failing every Monday** on these known upstream issues. Same `--audit-level=critical` makes it meaningful again.

## Verification

`npm audit --omit=dev --audit-level=critical` → exit **0** locally. CI will confirm.