### PR TITLE
[codex] update skills for market breadth

### DIFF
--- a/commands/scan.md
+++ b/commands/scan.md
@@ -20,15 +20,17 @@ Parse the arguments:
 1. **Determine asset type:** If the symbol looks like a crypto ticker (BTC, ETH, SOL, DOGE, ADA, XRP, DOT, AVAX, MATIC, LINK, UNI, ATOM), use crypto tools. Otherwise use stock tools.
 
 2. **For stocks**, run these tools in parallel:
-   - `tradingview_scan_indicators` -- technicals for the symbol + timeframe
+   - `tradingview_technicals` -- technicals for the symbol + timeframe
+   - `tradingview_quote` -- delayed quote for current price context
    - `finnhub_company_news` -- recent news (if available)
-   - `edgar_recent_filings` -- recent SEC filings (if available)
-   - `alpha_vantage_quote` -- current price (if available)
-   - `alpha_vantage_company_overview` -- fundamentals (if available)
+   - `edgar_company_filings` -- recent SEC filings (if available)
+   - `alphavantage_quote` -- current price (if available)
+   - `alphavantage_overview` -- fundamentals (if available)
 
 3. **For crypto**, run these tools in parallel:
-   - `crypto_scan_indicators` -- technicals for the pair + timeframe
-   - `coingecko_coin_data` -- price, market cap, volume
+   - `crypto_technicals` -- technicals for the pair + timeframe
+   - `crypto_quote` -- pair quote and 24h change
+   - `coingecko_coin` -- price, market cap, volume
 
 4. **Synthesize** the results into a concise market summary:
    - Current price and change

--- a/skills/TOOLS.md
+++ b/skills/TOOLS.md
@@ -1,6 +1,6 @@
 # stock-scanner-mcp Tool Reference
 
-Quick reference for all 54 MCP tools available to trading skills.
+Quick reference for all 66 MCP tools available to trading skills.
 
 ## TradingView (10 tools)
 
@@ -110,3 +110,32 @@ Quick reference for all 54 MCP tools available to trading skills.
 | `frankfurter_timeseries` | Daily rate history (max 90 days) | start_date, end_date, base, symbols |
 | `frankfurter_convert` | Convert amount between currencies | amount, from, to |
 | `frankfurter_currencies` | List all 31 supported currency codes | (none) |
+
+## Reddit (4 tools)
+
+| Tool | Purpose | Key Params |
+|------|---------|------------|
+| `reddit_trending` | Trending stock tickers from investing subreddits | subreddits, limit |
+| `reddit_mentions` | Mentions and top posts for a ticker | symbol, period |
+| `reddit_sentiment` | Keyword sentiment for a ticker | symbol, limit |
+| `reddit_watchlist_scan` | Batch scan watchlist tickers in one pass | symbols, period |
+
+## Market Breadth (1 tool)
+
+| Tool | Purpose | Key Params |
+|------|---------|------------|
+| `market_breadth` | Advance/decline ratio, % above SMA50/SMA200, 52-week highs/lows | universe, limit, newHighLowThresholdPct |
+
+## Workspace (7 tools)
+
+Requires the MCP server to run with `--enable-workspace`.
+
+| Tool | Purpose | Key Params |
+|------|---------|------------|
+| `workspace_get_profile` | Read saved trading profile and defaults | (none) |
+| `workspace_update_profile` | Save trading style, asset focus, cadence | tradingStyle, assetFocus, workflowCadence |
+| `workspace_list_watchlists` | List saved watchlists | (none) |
+| `workspace_create_watchlist` | Create a named watchlist | name |
+| `workspace_update_watchlist` | Replace watchlist symbols | name, symbols |
+| `workspace_get_thesis` | Read saved thesis for a symbol | symbol |
+| `workspace_save_thesis` | Save or update thesis for a symbol | symbol, summary, bullCase, bearCase, catalyst, timeframe |

--- a/skills/daily/market-close-recap/SKILL.md
+++ b/skills/daily/market-close-recap/SKILL.md
@@ -7,9 +7,9 @@ description: Produce an end-of-day market recap covering index performance, sect
 
 ## Overview
 
-Desk analyst closing the book. Collect final index prints, sector scores, top movers, volume anomalies, and late-day headlines in one parallel wave, then synthesize into a concise session narrative.
+Desk analyst closing the book. Collect final index prints, market breadth, sector scores, top movers, volume anomalies, and late-day headlines in one parallel wave, then synthesize into a concise session narrative.
 
-Announce at start: "Running market close recap -- collecting final prints, sectors, movers, and headlines."
+Announce at start: "Running market close recap -- collecting final prints, breadth, sectors, movers, and headlines."
 
 ## Data Collection
 
@@ -18,6 +18,7 @@ Announce at start: "Running market close recap -- collecting final prints, secto
 | Tool | Parameters | Priority |
 |------|-----------|----------|
 | `tradingview_market_indices` | (defaults) | REQUIRED |
+| `market_breadth` | universe=major_us | REQUIRED |
 | `sentiment_fear_greed` | (defaults) | REQUIRED |
 | `tradingview_sector_performance` | (defaults) | REQUIRED |
 | `tradingview_top_gainers` | limit=10 | REQUIRED |
@@ -36,8 +37,9 @@ DO NOT reproduce raw tool output. Synthesize a session narrative by answering:
 1. **Session driver** -- What single theme or catalyst best explains today's price action? Name it explicitly.
 2. **Sector leaders and laggards** -- Identify the top 2 and bottom 2 sectors. Explain WHY they led or lagged using news, earnings, or macro context.
 3. **Index divergence** -- Did the major indices move in lockstep or diverge? If NASDAQ outperformed Dow (or vice versa), note the growth-vs-value implication.
-4. **Unusual volume** -- Flag names with abnormal volume that are NOT already in the gainers/losers lists. These are tomorrow's watchlist candidates.
-5. **Sentiment alignment** -- Does the Fear & Greed reading match the day's action, or is there a disconnect worth noting?
+4. **Breadth confirmation** -- Did advance/decline ratio, % above SMA50/SMA200, and new highs/lows confirm the index move or reveal narrow leadership?
+5. **Unusual volume** -- Flag names with abnormal volume that are NOT already in the gainers/losers lists. These are tomorrow's watchlist candidates.
+6. **Sentiment alignment** -- Does the Fear & Greed reading match the day's action and breadth, or is there a disconnect worth noting?
 
 ## Output Format
 
@@ -47,6 +49,10 @@ DO NOT reproduce raw tool output. Synthesize a session narrative by answering:
 |-------|-------|--------|----------|
 
 Include S&P 500, NASDAQ Composite, Dow Jones, VIX. Add a one-sentence narrative below the table.
+
+### Market Breadth
+
+Report advance/decline ratio, % above SMA50, % above SMA200, new highs, and new lows. Add a one-sentence breadth verdict: CONFIRMED / NARROW / DETERIORATING.
 
 ### Sector Scorecard
 
@@ -85,4 +91,5 @@ Data from TradingView and Yahoo Finance is 15-minute delayed. CBOE and sentiment
 - Restating every gainer and loser without identifying the common thread that connects them.
 - Presenting sector data without explaining what drove the leaders and laggards.
 - Omitting the VIX context -- a rising VIX on a green day is a critical signal.
+- Calling a green index session risk-on when breadth is weak or new lows are expanding.
 - Listing headlines without connecting them to observed price action.

--- a/skills/daily/morning-briefing/SKILL.md
+++ b/skills/daily/morning-briefing/SKILL.md
@@ -7,9 +7,9 @@ description: Run a pre-market scan across indices, sectors, sentiment, and upcom
 
 ## Overview
 
-Institutional pre-market desk analyst briefing. Collect broad market indices, sector performance, sentiment, top movers, and upcoming catalysts in a single parallel wave, then cross-reference to produce a directional bias.
+Institutional pre-market desk analyst briefing. Collect broad market indices, sector performance, market breadth, sentiment, top movers, and upcoming catalysts in a single parallel wave, then cross-reference to produce a directional bias.
 
-Announce at start: "Running pre-market briefing -- collecting indices, sectors, sentiment, movers, and catalysts."
+Announce at start: "Running pre-market briefing -- collecting indices, sectors, breadth, sentiment, movers, and catalysts."
 
 ## Data Collection
 
@@ -21,6 +21,7 @@ Announce at start: "Running pre-market briefing -- collecting indices, sectors, 
 | `sentiment_fear_greed` | (defaults) | REQUIRED |
 | `finnhub_market_status` | (defaults) | REQUIRED |
 | `tradingview_sector_performance` | (defaults) | REQUIRED |
+| `market_breadth` | universe=major_us | REQUIRED |
 | `tradingview_top_gainers` | limit=10 | ENRICHMENT |
 | `tradingview_top_losers` | limit=10 | ENRICHMENT |
 | `tradingview_volume_breakout` | limit=10 | ENRICHMENT |
@@ -34,10 +35,11 @@ If any REQUIRED call fails, report the failure explicitly and proceed with avail
 
 DO NOT reproduce raw tool output. Cross-reference the collected data to answer:
 
-1. **Risk appetite agreement** -- Do index levels/futures direction and the Fear & Greed score point the same way? Flag any divergence as a caution signal.
-2. **Sector divergence** -- Which sectors diverge from the broad market direction? A defensive sector leading in a risk-on tape (or vice versa) is notable.
-3. **Volume clustering** -- Do volume breakout names cluster in one or two sectors? Flag as a potential rotation signal and name the sectors.
-4. **Catalyst check** -- Are any earnings or economic releases in the next 5 days likely to move the broad market or a specific sector? Highlight date, event, and expected impact.
+1. **Risk appetite agreement** -- Do index levels/futures direction, market breadth, and the Fear & Greed score point the same way? Flag any divergence as a caution signal.
+2. **Breadth confirmation** -- Are advancers/decliners, % above SMA50/SMA200, and new highs/lows confirming the index move or warning that leadership is narrow?
+3. **Sector divergence** -- Which sectors diverge from the broad market direction? A defensive sector leading in a risk-on tape (or vice versa) is notable.
+4. **Volume clustering** -- Do volume breakout names cluster in one or two sectors? Flag as a potential rotation signal and name the sectors.
+5. **Catalyst check** -- Are any earnings or economic releases in the next 5 days likely to move the broad market or a specific sector? Highlight date, event, and expected impact.
 
 ## Output Format
 
@@ -51,6 +53,10 @@ Include VIX, S&P 500, NASDAQ Composite, Dow Jones. Note market session status (p
 ### Fear & Greed
 
 Single line: score, label (Extreme Fear / Fear / Neutral / Greed / Extreme Greed), and one-week trend direction.
+
+### Market Breadth
+
+Single line: advance/decline ratio, % above SMA50, % above SMA200, and whether new highs or new lows dominate.
 
 ### Sector Map
 
@@ -83,5 +89,6 @@ Data from TradingView and Yahoo Finance is 15-minute delayed. CBOE and sentiment
 
 - Dumping raw JSON or full tool responses instead of synthesized tables.
 - Ignoring divergences between sentiment score and index direction -- these are the most valuable signals.
+- Ignoring weak breadth when indexes are green -- narrow leadership can invalidate a risk-on read.
 - Listing movers without connecting them to sector rotation or catalysts.
 - Stating a bias without citing the supporting data points that justify it.

--- a/skills/macro/macro-dashboard/SKILL.md
+++ b/skills/macro/macro-dashboard/SKILL.md
@@ -7,11 +7,11 @@ description: Build a comprehensive macroeconomic dashboard covering rates, infla
 
 ## Overview
 
-Act as a macro strategist. Collect key economic indicators, yield curve data, inflation metrics, labor market signals, and market sentiment to produce a unified macro picture. Cross-reference all data points to classify the current economic regime.
+Act as a macro strategist. Collect key economic indicators, yield curve data, inflation metrics, labor market signals, market breadth, and market sentiment to produce a unified macro picture. Cross-reference all data points to classify the current economic regime.
 
 **Prerequisite:** This skill requires FRED_API_KEY to be configured. Without it, only market indices and sentiment data are available.
 
-Announce at start: "Building macro dashboard -- collecting economic indicators, yield curve, inflation, labor, and sentiment data."
+Announce at start: "Building macro dashboard -- collecting economic indicators, yield curve, inflation, labor, breadth, and sentiment data."
 
 ## Data Collection
 
@@ -29,6 +29,7 @@ Announce at start: "Building macro dashboard -- collecting economic indicators, 
 | `fred_indicator`           | series_id=initial_claims    | ENRICHMENT  |
 | `fred_economic_calendar`   | limit=15                    | REQUIRED    |
 | `tradingview_market_indices` | (default)                 | REQUIRED    |
+| `market_breadth`           | universe=major_us           | ENRICHMENT  |
 | `sentiment_fear_greed`     | (default)                   | ENRICHMENT  |
 
 DO NOT proceed to analysis until ALL REQUIRED calls return. ENRICHMENT failures are acceptable.
@@ -41,7 +42,7 @@ Cross-reference the collected data across five dimensions:
 2. **Inflation Trajectory** -- Compare CPI and Core PCE to the Fed's 2% target. Determine if inflation is accelerating, decelerating, or anchored.
 3. **Labor Market Health** -- Assess unemployment rate direction and initial claims trend. Rising claims with rising unemployment = deterioration.
 4. **Fed Policy Stance** -- Current Fed Funds rate vs inflation readings. Is policy restrictive (rate > inflation) or accommodative?
-5. **Market Pricing of Risk** -- Extract VIX from market indices. Combine with Fear & Greed score. Elevated VIX (>25) with extreme fear = stress.
+5. **Market Pricing of Risk** -- Extract VIX from market indices. Combine with Fear & Greed score and breadth. Elevated VIX (>25) with extreme fear and weak breadth = stress.
 
 Synthesize all five dimensions into a single macro regime classification.
 
@@ -75,6 +76,7 @@ DO NOT reproduce raw tool output. Synthesize and interpret.
 ### Market Risk Gauges
 - VIX level and interpretation
 - Fear & Greed score and classification
+- Market breadth: advance/decline ratio, % above SMA50/SMA200, and new highs/lows if available
 
 ### Upcoming Releases (Next 2 Weeks)
 List the most market-moving releases from the economic calendar with dates.
@@ -95,3 +97,4 @@ Data from TradingView and Yahoo Finance is 15-minute delayed. CBOE and sentiment
 - Forgetting to compute the yield curve spread (just listing 2Y and 10Y separately)
 - Classifying regime based on a single indicator instead of cross-referencing all five dimensions
 - Ignoring the direction/trend of indicators and only reporting the latest snapshot value
+- Ignoring market breadth when market indices and sentiment disagree

--- a/skills/macro/sector-rotation/SKILL.md
+++ b/skills/macro/sector-rotation/SKILL.md
@@ -7,9 +7,9 @@ description: Analyze sector performance across timeframes, detect risk-on vs ris
 
 ## Overview
 
-Act as a sector strategist. Collect sector performance data across multiple timeframes, overlay technical signals on leaders and laggards, and determine whether capital is rotating toward risk-on or risk-off sectors. Produce actionable sector allocation guidance.
+Act as a sector strategist. Collect sector performance data across multiple timeframes, overlay market breadth and technical signals on leaders and laggards, and determine whether capital is rotating toward risk-on or risk-off sectors. Produce actionable sector allocation guidance.
 
-Announce at start: "Running sector rotation analysis -- collecting sector performance, market indices, and technical signals."
+Announce at start: "Running sector rotation analysis -- collecting sector performance, breadth, market indices, and technical signals."
 
 ## Data Collection
 
@@ -19,6 +19,7 @@ Announce at start: "Running sector rotation analysis -- collecting sector perfor
 |------------------------------|-----------------------|-------------|
 | `tradingview_sector_performance` | (default)         | REQUIRED    |
 | `tradingview_market_indices`     | (default)         | REQUIRED    |
+| `market_breadth`                 | universe=major_us | ENRICHMENT  |
 | `sentiment_fear_greed`           | (default)         | ENRICHMENT  |
 | `fred_indicator`                 | series_id=treasury_10y | ENRICHMENT |
 
@@ -39,7 +40,7 @@ DO NOT proceed to analysis until ALL REQUIRED calls return. ENRICHMENT failures 
 Cross-reference the collected data across four dimensions:
 
 1. **Timeframe Divergence** -- Compare 1-day vs 1-week vs 1-month vs YTD performance for each sector. Short-term moves diverging from longer-term trends signal emerging rotation.
-2. **Risk Appetite** -- Defensive sectors (XLU, XLP, XLV) outperforming cyclicals (XLY, XLI, XLF) = RISK-OFF. Cyclicals outperforming defensives = RISK-ON. Mixed leadership = no clear signal.
+2. **Risk Appetite** -- Defensive sectors (XLU, XLP, XLV) outperforming cyclicals (XLY, XLI, XLF) = RISK-OFF. Cyclicals outperforming defensives = RISK-ON. Mixed leadership = no clear signal. Use breadth as confirmation: strong breadth confirms broad risk-on rotation; weak breadth implies narrow leadership.
 3. **Rate Sensitivity** -- Compare rate-sensitive sectors (XLU, XLRE) performance to 10Y yield direction. Rising yields should pressure these sectors. Outperformance despite rising yields is a strong signal.
 4. **Technical Confirmation** -- Use RSI and trend data from Wave 2 to confirm or contradict the rotation signal. Overbought leaders (RSI >70) may reverse. Oversold laggards (RSI <30) may bounce.
 
@@ -72,6 +73,9 @@ DO NOT reproduce raw tool output. Synthesize and interpret.
 ### Rate Sensitivity
 Note how rate-sensitive sectors (XLU, XLRE) are behaving relative to the current 10Y yield direction. Flag any divergence.
 
+### Breadth Confirmation
+State whether market breadth confirms or contradicts the sector rotation signal. Reference advance/decline ratio, % above SMA50/SMA200, and new highs/lows when available.
+
 ### Sector Picks
 
 **Overweight (top 2):**
@@ -90,3 +94,4 @@ Data from TradingView and Yahoo Finance is 15-minute delayed. CBOE and sentiment
 - Classifying rotation signal without comparing defensive vs cyclical sector groups explicitly
 - Skipping Wave 2 technicals and making sector picks without RSI or trend confirmation
 - Ignoring interest rate direction when assessing rate-sensitive sectors like Utilities and Real Estate
+- Treating leadership in one or two sectors as broad risk-on rotation without checking market breadth

--- a/skills/market-data/SKILL.md
+++ b/skills/market-data/SKILL.md
@@ -8,29 +8,42 @@ description: Guidance on using stock and crypto market data tools effectively --
 ## Available Tool Categories
 
 ### Stock Technical Analysis (TradingView)
-- `tradingview_scan_indicators` -- full technical scan for a stock symbol
+- `tradingview_scan` -- custom stock scanner with filters and columns
+- `tradingview_quote` -- delayed quote for one or more tickers
+- `tradingview_technicals` -- RSI, MACD, moving averages, pivots, and ratings
+- `tradingview_market_indices` -- VIX, S&P 500, NASDAQ, Dow, and related index context
+- `tradingview_sector_performance` -- 11 sector ETFs across multiple timeframes
 - `tradingview_top_gainers` / `tradingview_top_losers` -- market movers
+- `tradingview_top_volume` -- highest volume stocks
 - `tradingview_volume_breakout` -- unusual volume detection
-- `tradingview_rating_filter` -- filter by buy/sell rating
+- Use `tradingview_scan` filters and columns for rating-based stock screens
+- `market_breadth` -- advance/decline ratio, % above SMA50/SMA200, and new highs/lows
 
 ### Crypto Technical Analysis (TradingView Crypto)
-- `crypto_scan_indicators` -- full technical scan for crypto pairs
-- `crypto_top_gainers` / `crypto_top_losers` -- crypto movers
-- `crypto_volume_breakout` -- unusual crypto volume
+- `crypto_scan` -- custom crypto scanner with filters and columns
+- `crypto_quote` -- quote and 24h change for crypto pairs
+- `crypto_technicals` -- RSI, MACD, moving averages, pivots, and ratings
+- `crypto_top_gainers` -- top gaining crypto pairs
 
 ### News & Events
 - `finnhub_company_news` -- recent company news (7-day lookback)
 - `finnhub_earnings_calendar` -- upcoming/recent earnings
-- `edgar_search_filings` -- search SEC 8-K filings
-- `edgar_recent_filings` -- recent material events
+- `edgar_search` -- search SEC filings by keyword, form, ticker, and date range
+- `edgar_company_filings` -- recent company filings
 
 ### Prices & Fundamentals
-- `alpha_vantage_quote` -- current price, volume, change
-- `alpha_vantage_daily_history` -- daily OHLCV (100 days)
-- `alpha_vantage_company_overview` -- PE, EPS, market cap, sector
+- `alphavantage_quote` -- current price, volume, change
+- `alphavantage_daily` -- daily OHLCV history
+- `alphavantage_overview` -- PE, EPS, market cap, sector
+
+### Social Sentiment
+- `reddit_trending` -- trending tickers from investing subreddits
+- `reddit_mentions` -- mentions and top posts for a ticker
+- `reddit_sentiment` -- keyword sentiment for a ticker
+- `reddit_watchlist_scan` -- batch scan watchlist tickers
 
 ### Crypto Market Data
-- `coingecko_coin_data` -- price, market cap, 24h volume
+- `coingecko_coin` -- price, market cap, 24h volume
 - `coingecko_trending` -- trending coins
 - `coingecko_global` -- total market cap, BTC dominance
 
@@ -38,11 +51,14 @@ description: Guidance on using stock and crypto market data tools effectively --
 
 | User Question | Tools to Use |
 |---|---|
-| "What do the charts say about AAPL?" | `tradingview_scan_indicators` |
+| "What do the charts say about AAPL?" | `tradingview_technicals`, `tradingview_quote` |
 | "What's moving today?" | `tradingview_top_gainers`, `tradingview_top_losers`, `tradingview_volume_breakout` |
-| "Any news on TSLA?" | `finnhub_company_news`, `edgar_recent_filings` |
-| "Is MSFT fairly valued?" | `alpha_vantage_company_overview`, `alpha_vantage_quote` |
-| "How's crypto doing?" | `coingecko_global`, `coingecko_trending`, `crypto_top_gainers` |
+| "How broad is this rally?" | `market_breadth`, `tradingview_market_indices` |
+| "What's the market regime?" | `tradingview_market_indices`, `market_breadth`, `sentiment_fear_greed`, `tradingview_sector_performance` |
+| "Any news on TSLA?" | `finnhub_company_news`, `edgar_company_filings` |
+| "Is MSFT fairly valued?" | `alphavantage_overview`, `alphavantage_quote` |
+| "How's crypto doing?" | `coingecko_global`, `coingecko_trending`, `crypto_top_gainers`, `crypto_quote` |
+| "What is Reddit focused on?" | `reddit_trending`, `reddit_mentions`, `reddit_sentiment` |
 | "Full analysis of AAPL" | All stock tools in parallel |
 
 ## Key Principles

--- a/skills/risk/risk-check/SKILL.md
+++ b/skills/risk/risk-check/SKILL.md
@@ -34,6 +34,7 @@ Normalize ticker to uppercase. Set `ticker` variable.
 | `options_implied_move`        | symbol=ticker                               | REQUIRED    |
 | `finnhub_short_interest`      | symbol=ticker                               | REQUIRED    |
 | `finnhub_earnings_calendar`   | from=today, to=today+14, symbol=ticker      | REQUIRED    |
+| `market_breadth`              | universe=major_us                           | ENRICHMENT  |
 | `tradingview_sector_performance` |                                           | ENRICHMENT  |
 | `sentiment_fear_greed`        |                                             | ENRICHMENT  |
 | `options_max_pain`            | symbol=ticker                               | ENRICHMENT  |
@@ -71,6 +72,8 @@ After scoring, derive key levels:
 - Max pain: options max pain strike (if available)
 - Suggested stop: below nearest support level, or 2-3% below entry for a standard risk tolerance
 
+Use market breadth as qualitative context, not as a ninth flag. Weak breadth, low % above SMA50/SMA200, or expanding new lows should make sizing commentary more conservative when the flag score is already MODERATE or worse.
+
 ## Output Format
 
 ### [TICKER] -- Pre-Trade Risk Assessment
@@ -97,7 +100,7 @@ PASS = flag NOT triggered (favorable). FAIL = flag triggered (risk present).
 **Risk Score: X / 8 flags -- [LEVEL]**
 
 **Market Context**
-VIX level and trend, Fear & Greed index value and label, broad market direction.
+VIX level and trend, Fear & Greed index value and label, broad market direction, and breadth confirmation if available.
 
 **Sector Context**
 Stock's sector, sector rank today, top and bottom 3 sectors.
@@ -132,3 +135,5 @@ Data from TradingView and Yahoo Finance is 15-minute delayed. CBOE and sentiment
   see VIX=23.5 (PASS), not just PASS.
 - DO NOT give position sizing advice without referencing the flag count. Every
   sizing recommendation MUST tie back to the risk score.
+- DO NOT add market breadth as a ninth scored flag. Use it to qualify the
+  market context and sizing language only.

--- a/skills/workspace/workspace-morning-brief/SKILL.md
+++ b/skills/workspace/workspace-morning-brief/SKILL.md
@@ -24,13 +24,14 @@ Based ONLY on the symbols found in the user's workspace, fetch relevant data usi
 - **Crypto Exposure Check:** If the watchlist contains crypto-exposed equities (e.g., MARA, CIFR, COIN) or Bitcoin, you MUST fetch the current price and 24h change of BTC (using `tradingview_quote` for `BINANCE:BTCUSDT`). Evaluate the correlation and note if the stocks are tracking or diverging from the BTC move.
 - **Event Risk Check:** For active equity names (e.g., HOOD, SOFI), check for upcoming earnings today using `finnhub_earnings_calendar` and recent news using `finnhub_company_news`.
 - **Risk Tone Check:** If the watchlist contains Gold or Silver (or proxies like GLD/SLV), fetch their current prices. Note any sharp moves that might change the overall market risk tone.
-- **Market Pulse:** Fetch a basic S&P 500 / VIX quote (`tradingview_quote` for `SPY` and `VIX`) to establish the baseline market direction.
+- **Market Pulse:** Fetch a basic S&P 500 / VIX quote (`tradingview_quote` for `SPY` and `VIX`) plus `market_breadth` with universe=major_us to establish whether the baseline market direction is broad or narrow.
 
 ### STEP 3: SYNTHESIZE THE BRIEF
 Do NOT give a generic, broad market recap. Structure your response to answer the following questions specifically about the user's watchlist:
 
 #### 1. What Matters Today
 Highlight the overarching theme for the user's specific portfolio (e.g., "Crypto proxies are leading the market today," or "A defensive risk-off tone driven by a drop in Gold").
+Include whether broad-market breadth supports or contradicts that theme when it affects the user's saved names.
 
 #### 2. Active Names & Event Risk
 List the tickers from the watchlist that are moving significantly (pre-market or early trading) or have an immediate catalyst (Earnings, News, Options Flow).


### PR DESCRIPTION
## Summary
- refresh skills/TOOLS.md to the current 66-tool surface, including Reddit, workspace, and market breadth tools
- add market_breadth guidance to broad-market skills: morning briefing, market close recap, sector rotation, macro dashboard, risk check, and workspace morning brief
- update market-data and /scan docs to use current MCP tool names after the merged market-breadth capability work
- add npm run validate-doc-tools to catch stale MCP tool references in skills and commands, with CI/PR checklist coverage

## Validation
- npm run lint
- npm run validate-tools (all 66 tools passed; 54 warning-style docs notes remain)
- npm run validate-doc-tools (252 references checked)
- npm run validate-structure
- npm test -- --run (35 files, 432 tests)
- npm run build
- post-rebase targeted tests: npx vitest run src/scripts/__tests__/validate-doc-tool-references.test.ts src/scripts/__tests__/validate-tools.test.ts src/scripts/__tests__/generate-sidecar-openapi.test.ts src/sidecar/__tests__/server.test.ts