### PR TITLE
[codex] validate skill tool references

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,7 @@
 - [ ] `npm run lint` passes
 - [ ] `npm test` passes
 - [ ] `npm run validate-tools` passes
+- [ ] `npm run validate-doc-tools` passes
 - [ ] `npm run build` succeeds
 - [ ] Tests added or updated for changed code
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Validate tools
         run: npm run validate-tools
 
+      - name: Validate docs tool references
+        run: npm run validate-doc-tools
+
       - name: Build
         run: npm run build
 

--- a/README.md
+++ b/README.md
@@ -457,8 +457,9 @@ All modules use in-memory TTL caching to minimize API calls.
 
 ```bash
 npm install && npm run build && npm test
-npm run lint          # TypeScript type checking
-npm run validate-tools # Tool description quality check
+npm run lint               # TypeScript type checking
+npm run validate-tools     # Tool description quality check
+npm run validate-doc-tools # Skill/command tool reference check
 ```
 
 ## Credibility Artifacts

--- a/docs/development-standards.md
+++ b/docs/development-standards.md
@@ -401,10 +401,11 @@ Before any PR is merged:
 npm run lint            # TypeScript type checking — must pass
 npm test                # All tests — must pass
 npm run validate-tools  # Tool description quality — must pass
+npm run validate-doc-tools # Skill/command tool references — must pass
 npm run build           # Build — must succeed
 ```
 
-All four MUST pass. No exceptions.
+All five MUST pass. No exceptions.
 
 ### Tool Description Validation
 
@@ -416,6 +417,12 @@ All four MUST pass. No exceptions.
 4. **Value-scale documentation** — tools returning recommendations/ratings document the scale
 
 Runs in CI alongside lint and test. See `src/scripts/validate-tools.ts` for implementation.
+
+### Skill and Command Tool Reference Validation
+
+`npm run validate-doc-tools` scans `skills/**/*.md` and `commands/**/*.md` for backticked MCP tool references and fails if any referenced tool is not registered in code. This prevents skills from instructing the model to call stale or nonexistent tools after tool names change.
+
+Runs in CI alongside lint, test, and tool validation. See `src/scripts/validate-doc-tool-references.ts` for implementation.
 
 ### Code Hygiene
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lint": "tsc --noEmit",
     "generate-openapi": "tsx src/scripts/generate-sidecar-openapi.ts",
     "validate-tools": "tsx src/scripts/validate-tools.ts",
+    "validate-doc-tools": "tsx src/scripts/validate-doc-tool-references.ts",
     "validate-structure": "tsx src/scripts/validate-structure.ts",
     "prepublishOnly": "npm run build && npm test"
   },

--- a/src/scripts/__tests__/generate-sidecar-openapi.test.ts
+++ b/src/scripts/__tests__/generate-sidecar-openapi.test.ts
@@ -60,7 +60,7 @@ describe("generateOpenApiSpec", () => {
     expect(seriesId.required).toBe(false);
   });
 
-  it("contains all 65 tools (mapped to routes)", () => {
+  it("contains the registered tool routes", () => {
     // Some routes map to the same tool (aliases like /edgar/filings)
     // but every tool should be represented at least once.
     const toolNames = new Set<string>();

--- a/src/scripts/__tests__/validate-doc-tool-references.test.ts
+++ b/src/scripts/__tests__/validate-doc-tool-references.test.ts
@@ -1,0 +1,53 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { execSync } from "node:child_process";
+import { afterEach, describe, expect, it } from "vitest";
+import { validateDocToolReferences } from "../validate-doc-tool-references.js";
+
+describe("validate-doc-tool-references script", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.map(dir => rm(dir, { recursive: true, force: true })));
+    tempDirs.length = 0;
+  });
+
+  it("passes for current skills and commands", () => {
+    const output = execSync("npx tsx src/scripts/validate-doc-tool-references.ts", {
+      encoding: "utf8",
+      cwd: process.cwd(),
+    });
+
+    expect(output).toContain("MCP tool references are registered");
+  });
+
+  it("reports stale tool-like references and ignores non-tool identifiers", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "doc-tool-refs-"));
+    tempDirs.push(root);
+
+    const docPath = path.join(root, "SKILL.md");
+    await writeFile(
+      docPath,
+      [
+        "# Synthetic Skill",
+        "",
+        "Use `market_breadth` with `treasury_10y` context.",
+        "Do not use stale `tradingview_scan_indicators`.",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const result = await validateDocToolReferences([root]);
+
+    expect(result.toolReferences).toBe(2);
+    expect(result.unknownReferences).toHaveLength(1);
+    expect(result.unknownReferences[0]).toMatchObject({
+      file: docPath,
+      line: 4,
+      name: "tradingview_scan_indicators",
+    });
+    expect(result.unknownReferences[0].suggestion).toBeDefined();
+  });
+});

--- a/src/scripts/tool-registry.ts
+++ b/src/scripts/tool-registry.ts
@@ -1,0 +1,43 @@
+import * as os from "node:os";
+import { createAlphaVantageModule } from "../modules/alpha-vantage/index.js";
+import { createCoingeckoModule } from "../modules/coingecko/index.js";
+import { createFinnhubModule } from "../modules/finnhub/index.js";
+import { createFrankfurterModule } from "../modules/frankfurter/index.js";
+import { createFredModule } from "../modules/fred/index.js";
+import { createMarketBreadthModule } from "../modules/market-breadth/index.js";
+import { createOptionsModule } from "../modules/options/index.js";
+import { createOptionsCboeModule } from "../modules/options-cboe/index.js";
+import { createRedditModule } from "../modules/reddit/index.js";
+import { createSecEdgarModule } from "../modules/sec-edgar/index.js";
+import { createSentimentModule } from "../modules/sentiment/index.js";
+import { createTradingviewModule } from "../modules/tradingview/index.js";
+import { createTradingviewCryptoModule } from "../modules/tradingview-crypto/index.js";
+import { createWorkspaceModule } from "../modules/workspace/index.js";
+import type { ModuleDefinition } from "../shared/types.js";
+
+export function buildAllModules(): ModuleDefinition[] {
+  return [
+    createTradingviewModule(),
+    createTradingviewCryptoModule(),
+    createSecEdgarModule(),
+    createCoingeckoModule(),
+    createOptionsModule(),
+    createOptionsCboeModule(),
+    createFinnhubModule("mock-key"),
+    createAlphaVantageModule("mock-key"),
+    createFredModule("mock-key"),
+    createSentimentModule(),
+    createFrankfurterModule(),
+    createRedditModule(),
+    createMarketBreadthModule(),
+    createWorkspaceModule(os.tmpdir()),
+  ];
+}
+
+export function getRegisteredToolNames(modules = buildAllModules()): Set<string> {
+  return new Set(modules.flatMap(module => module.tools.map(tool => tool.name)));
+}
+
+export function getRegisteredToolPrefixes(toolNames = getRegisteredToolNames()): Set<string> {
+  return new Set([...toolNames].map(name => name.split("_")[0]));
+}

--- a/src/scripts/validate-doc-tool-references.ts
+++ b/src/scripts/validate-doc-tool-references.ts
@@ -1,0 +1,173 @@
+#!/usr/bin/env tsx
+/**
+ * Validate that tool names referenced in skill and command markdown exist.
+ *
+ * Scans backticked identifiers such as `tradingview_quote` and fails when the
+ * name looks like an MCP tool but is not registered by the current code.
+ *
+ * Usage: npm run validate-doc-tools
+ */
+
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+import { getRegisteredToolNames, getRegisteredToolPrefixes } from "./tool-registry.js";
+
+const DEFAULT_ROOTS = ["skills", "commands"];
+const TOOL_REFERENCE_PATTERN = /`([a-z][a-z0-9]*(?:_[a-z0-9]+)+)`/g;
+
+export interface UnknownToolReference {
+  file: string;
+  line: number;
+  column: number;
+  name: string;
+  suggestion?: string;
+}
+
+interface ScanResult {
+  markdownFiles: number;
+  toolReferences: number;
+  unknownReferences: UnknownToolReference[];
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function collectMarkdownFiles(root: string): Promise<string[]> {
+  if (!(await pathExists(root))) return [];
+
+  const stat = await fs.stat(root);
+  if (stat.isFile()) {
+    return root.endsWith(".md") ? [root] : [];
+  }
+
+  const entries = await fs.readdir(root, { withFileTypes: true });
+  const files = await Promise.all(entries.map(async entry => {
+    const fullPath = path.join(root, entry.name);
+    if (entry.isDirectory()) return collectMarkdownFiles(fullPath);
+    return entry.isFile() && entry.name.endsWith(".md") ? [fullPath] : [];
+  }));
+
+  return files.flat().sort();
+}
+
+function lineAndColumn(content: string, index: number): { line: number; column: number } {
+  const before = content.slice(0, index);
+  const lines = before.split("\n");
+  return { line: lines.length, column: lines[lines.length - 1].length + 1 };
+}
+
+function editDistance(left: string, right: string): number {
+  const rows = left.length + 1;
+  const cols = right.length + 1;
+  const costs = Array.from({ length: rows }, () => Array<number>(cols).fill(0));
+
+  for (let i = 0; i < rows; i++) costs[i][0] = i;
+  for (let j = 0; j < cols; j++) costs[0][j] = j;
+
+  for (let i = 1; i < rows; i++) {
+    for (let j = 1; j < cols; j++) {
+      const substitution = costs[i - 1][j - 1] + (left[i - 1] === right[j - 1] ? 0 : 1);
+      costs[i][j] = Math.min(
+        costs[i - 1][j] + 1,
+        costs[i][j - 1] + 1,
+        substitution,
+      );
+    }
+  }
+
+  return costs[left.length][right.length];
+}
+
+function suggestToolName(name: string, registeredTools: Set<string>): string | undefined {
+  let best: { name: string; distance: number } | undefined;
+
+  for (const tool of registeredTools) {
+    const distance = editDistance(name, tool);
+    if (!best || distance < best.distance) {
+      best = { name: tool, distance };
+    }
+  }
+
+  if (!best) return undefined;
+  const threshold = Math.max(4, Math.floor(name.length * 0.4));
+  return best.distance <= threshold ? best.name : undefined;
+}
+
+function isToolLikeReference(name: string, knownPrefixes: Set<string>): boolean {
+  const prefix = name.split("_")[0];
+  return knownPrefixes.has(prefix);
+}
+
+export async function validateDocToolReferences(roots = DEFAULT_ROOTS): Promise<ScanResult> {
+  const registeredTools = getRegisteredToolNames();
+  const knownPrefixes = getRegisteredToolPrefixes(registeredTools);
+  const files = (await Promise.all(roots.map(collectMarkdownFiles))).flat().sort();
+  const unknownReferences: UnknownToolReference[] = [];
+  let toolReferences = 0;
+
+  for (const file of files) {
+    const content = await fs.readFile(file, "utf8");
+    const seenInFile = new Set<string>();
+
+    for (const match of content.matchAll(TOOL_REFERENCE_PATTERN)) {
+      const name = match[1];
+      if (!isToolLikeReference(name, knownPrefixes)) continue;
+
+      toolReferences++;
+      if (registeredTools.has(name)) continue;
+
+      const dedupeKey = `${file}:${name}`;
+      if (seenInFile.has(dedupeKey)) continue;
+      seenInFile.add(dedupeKey);
+
+      const location = lineAndColumn(content, match.index ?? 0);
+      unknownReferences.push({
+        file,
+        name,
+        line: location.line,
+        column: location.column,
+        suggestion: suggestToolName(name, registeredTools),
+      });
+    }
+  }
+
+  return {
+    markdownFiles: files.length,
+    toolReferences,
+    unknownReferences,
+  };
+}
+
+async function main(): Promise<void> {
+  const result = await validateDocToolReferences();
+
+  console.log("\n\u001b[1m\u001b[36mStock Scanner Doc Tool Reference Validator\u001b[0m");
+  console.log("──────────────────────────────────────────────────");
+  console.log(`Scanned ${result.markdownFiles} markdown files under ${DEFAULT_ROOTS.join(", ")}.`);
+
+  if (result.unknownReferences.length === 0) {
+    console.log(`\n\u001b[32m\u001b[1m✓ All ${result.toolReferences} MCP tool references are registered\u001b[0m\n`);
+    return;
+  }
+
+  console.log(`\n\u001b[31m\u001b[1m✗ Unknown MCP tool references found:\u001b[0m`);
+  for (const issue of result.unknownReferences) {
+    const suggestion = issue.suggestion ? ` Did you mean \`${issue.suggestion}\`?` : "";
+    console.log(`  ${issue.file}:${issue.line}:${issue.column} \`${issue.name}\` is not registered.${suggestion}`);
+  }
+  console.log();
+  process.exitCode = 1;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch(error => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/src/scripts/validate-tools.ts
+++ b/src/scripts/validate-tools.ts
@@ -13,22 +13,8 @@
  */
 
 import { z } from "zod";
-import { createTradingviewModule } from "../modules/tradingview/index.js";
-import { createTradingviewCryptoModule } from "../modules/tradingview-crypto/index.js";
-import { createSecEdgarModule } from "../modules/sec-edgar/index.js";
-import { createCoingeckoModule } from "../modules/coingecko/index.js";
-import { createFinnhubModule } from "../modules/finnhub/index.js";
-import { createAlphaVantageModule } from "../modules/alpha-vantage/index.js";
-import { createOptionsModule } from "../modules/options/index.js";
-import { createOptionsCboeModule } from "../modules/options-cboe/index.js";
-import { createFredModule } from "../modules/fred/index.js";
-import { createSentimentModule } from "../modules/sentiment/index.js";
-import { createFrankfurterModule } from "../modules/frankfurter/index.js";
-import { createRedditModule } from "../modules/reddit/index.js";
-import { createWorkspaceModule } from "../modules/workspace/index.js";
-import { createMarketBreadthModule } from "../modules/market-breadth/index.js";
-import type { ModuleDefinition, ToolDefinition } from "../shared/types.js";
-import * as os from "node:os";
+import type { ToolDefinition } from "../shared/types.js";
+import { buildAllModules } from "./tool-registry.js";
 
 // ── Constants ────────────────────────────────────────────────────────
 
@@ -217,25 +203,6 @@ function checkValueScale(tool: ToolDefinition, moduleName: string): Issue | null
 }
 
 // ── Main ─────────────────────────────────────────────────────────────
-
-function buildAllModules(): ModuleDefinition[] {
-  return [
-    createTradingviewModule(),
-    createTradingviewCryptoModule(),
-    createSecEdgarModule(),
-    createCoingeckoModule(),
-    createOptionsModule(),
-    createOptionsCboeModule(),
-    createFinnhubModule("mock-key"),
-    createAlphaVantageModule("mock-key"),
-    createFredModule("mock-key"),
-    createSentimentModule(),
-    createFrankfurterModule(),
-    createRedditModule(),
-    createMarketBreadthModule(),
-    createWorkspaceModule(os.tmpdir()),
-  ];
-}
 
 function validate(): boolean {
   const modules = buildAllModules();


### PR DESCRIPTION
## Summary
- add npm run validate-doc-tools to scan skills and commands for stale MCP tool references
- reuse a shared tool registry helper so validation reads the registered tool surface from code
- wire the check into CI, PR checklist, README, and development standards

## Validation
- npm run lint
- npm run validate-doc-tools (252 references checked)
- npx vitest run src/scripts/__tests__/validate-doc-tool-references.test.ts src/scripts/__tests__/validate-tools.test.ts src/scripts/__tests__/generate-sidecar-openapi.test.ts
- npm run validate-tools (all 66 tools passed; existing 54 warnings remain)
- npm test -- --run (35 files, 432 tests)
- npm run build
- npm run validate-structure