### PR TITLE
chore: release v1.18.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stock-scanner",
   "description": "Stock and crypto market data for Claude Code -- technical indicators, news, filings, fundamentals, and crypto metrics from free APIs",
-  "version": "1.17.1",
+  "version": "1.18.0",
   "author": {
     "name": "Yordan Yordanov"
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-**Version:** 1.17.1 — Published on npm as `stock-scanner-mcp`
+**Version:** 1.18.0 — Published on npm as `stock-scanner-mcp`
 **Modules:** 14 implemented (66 tools total)
 
 Planning docs (historical): `docs/architecture.md`, `docs/plans/` — reference only, not actively maintained

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stock-scanner-mcp",
   "mcpName": "io.github.yyordanov-tradu/stock-scanner-mcp",
-  "version": "1.17.1",
+  "version": "1.18.0",
   "description": "MCP server providing Claude Code with real-time stock and crypto market data, SEC filings, insider trades, and technical analysis",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release version 1.18.0 containing the new keyless market breadth module and tool, documentation updates, and tool reference validation pipeline.