### PR TITLE
chore(docs): update status of planning documents

### DIFF
--- a/docs/plans/2026-04-02-market-workspace-proposal.md
+++ b/docs/plans/2026-04-02-market-workspace-proposal.md
@@ -1,7 +1,7 @@
 # Market Workspace Proposal
 
 **Date:** 2026-04-02
-**Status:** Revised after review
+**Status:** Implemented
 **Author:** Yordan Yordanov + AI Assistant
 
 ## Overview

--- a/docs/plans/2026-04-03-market-workspace-winner-plan.md
+++ b/docs/plans/2026-04-03-market-workspace-winner-plan.md
@@ -1,7 +1,7 @@
 # Winner Plan: Market Workspace V1
 
 **Date:** 2026-04-03
-**Status:** Draft for review
+**Status:** Implemented
 **Author:** Yordan Yordanov + Codex
 
 ## Decision Summary

--- a/docs/plans/2026-06-16-reddit-watchlist-scan.md
+++ b/docs/plans/2026-06-16-reddit-watchlist-scan.md
@@ -1,6 +1,6 @@
 ---
 name: reddit-watchlist-scan
-status: revised-after-readiness-review
+status: implemented
 created: 2026-06-16T08:05:00Z
 updated: 2026-06-16T08:55:00Z
 issue: 197

--- a/docs/plans/2026-07-04-market-breadth-tool.md
+++ b/docs/plans/2026-07-04-market-breadth-tool.md
@@ -1,7 +1,7 @@
 # Market Breadth Tool Implementation Plan
 
 **Date:** 2026-07-04
-**Status:** Draft for review
+**Status:** Implemented
 **Author:** Codex
 **GitHub issue:** #92
 

--- a/docs/plans/2026-07-04-sqlite-workspace-and-cache.md
+++ b/docs/plans/2026-07-04-sqlite-workspace-and-cache.md
@@ -1,7 +1,7 @@
 # SQLite Workspace and Persistent Cache Implementation Plan
 
 **Date:** 2026-07-04
-**Status:** Draft for review
+**Status:** Not implemented
 **Author:** Antigravity (AI Architect)
 
 ---

--- a/docs/plans/2026-07-04-unified-market-data-layer.md
+++ b/docs/plans/2026-07-04-unified-market-data-layer.md
@@ -1,7 +1,7 @@
 # Unified Market Data Layer (Smart Router) Implementation Plan
 
 **Date:** 2026-07-04
-**Status:** Draft for review
+**Status:** Not implemented
 **Author:** Antigravity (AI Architect)
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stock-scanner-mcp",
-  "version": "1.17.1",
+  "version": "1.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stock-scanner-mcp",
-      "version": "1.17.1",
+      "version": "1.18.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",


### PR DESCRIPTION
Sets the status of recently worked on or proposed planning documents under `docs/plans/` to either `Implemented` or `Not implemented` in accordance with current state.