### PR TITLE
chore(plugin): add marketplace description and repo links to manifests

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
   "name": "tradu-marketplace",
+  "description": "Market data plugins for Claude Code -- stock and crypto scanners, technical analysis, SEC filings, and macro indicators from free APIs",
   "owner": {
     "name": "Yordan Yordanov"
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,5 +6,7 @@
     "name": "Yordan Yordanov"
   },
   "license": "MIT",
+  "homepage": "https://github.com/yyordanov-tradu/stock-scanner-mcp",
+  "repository": "https://github.com/yyordanov-tradu/stock-scanner-mcp",
   "keywords": ["stocks", "crypto", "trading", "market-data", "technical-analysis"]
 }

--- a/src/__tests__/plugin-manifests.test.ts
+++ b/src/__tests__/plugin-manifests.test.ts
@@ -20,6 +20,8 @@ interface PackageJson {
 interface PluginJson {
   name: string;
   version: string;
+  homepage: string;
+  repository: string;
 }
 interface McpServer {
   command: string;
@@ -35,6 +37,7 @@ interface MarketplacePlugin {
 }
 interface MarketplaceJson {
   name: string;
+  description: string;
   owner: { name: string };
   plugins: MarketplacePlugin[];
 }
@@ -63,6 +66,22 @@ describe("plugin manifests", () => {
     expect(marketplace.plugins.length).toBeGreaterThan(0);
     expect(marketplace.plugins[0].name).toBe("stock-scanner");
     expect(marketplace.plugins[0].name).toBe(plugin.name);
+  });
+
+  it("plugin.json homepage and repository point at the GitHub repo", () => {
+    const plugin = readJson(".claude-plugin/plugin.json") as PluginJson;
+    // Directory listings surface these links — they must exist and be valid URLs.
+    const repoUrl = "https://github.com/yyordanov-tradu/stock-scanner-mcp";
+    expect(plugin.homepage).toBe(repoUrl);
+    expect(plugin.repository).toBe(repoUrl);
+    expect(() => new URL(plugin.homepage)).not.toThrow();
+  });
+
+  it("marketplace.json has a non-empty description", () => {
+    const marketplace = readJson(".claude-plugin/marketplace.json") as MarketplaceJson;
+    // `claude plugin validate` warns when this is missing — keep it present.
+    expect(typeof marketplace.description).toBe("string");
+    expect(marketplace.description.length).toBeGreaterThan(0);
   });
 
   it("marketplace.json has a required non-empty owner.name", () => {


### PR DESCRIPTION
## Summary

Prepares the plugin for submission to the Claude Code community marketplace by fixing the two metadata gaps found during `claude plugin validate`:

- **`.claude-plugin/marketplace.json`**: add the missing top-level `description` — this was the one warning reported by `claude plugin validate`. It now passes clean.
- **`.claude-plugin/plugin.json`**: add `homepage` and `repository` links pointing at this repo, so directory listings can link back to the source.

## Tests

Extended `src/__tests__/plugin-manifests.test.ts` with two new assertions so these fields cannot silently regress:
- `plugin.json` `homepage`/`repository` point at the GitHub repo and are valid URLs
- `marketplace.json` has a non-empty `description`

## Quality gates

- `npm run lint` ✅
- `npm test` ✅ 439 passed (36 files)
- `npm run validate-tools` ✅ 66 tools passed
- `npm run build` ✅
- `claude plugin validate` ✅ passes with zero warnings (previously 1 warning)

No runtime code changes — manifest metadata and tests only. Does not touch or depend on PR #244.