### PR TITLE
fix(test): parse SEC EDGAR host instead of URL substring match (CodeQL #16)

### DIFF
--- a/src/sidecar/__tests__/server.test.ts
+++ b/src/sidecar/__tests__/server.test.ts
@@ -953,7 +953,9 @@ describe("sidecar server", () => {
   it("GET /sec-edgar/company-filings returns filing data", async () => {
     vi.stubGlobal("fetch", vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
       const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
-      if (urlStr.includes("search-index") || urlStr.includes("efts.sec.gov")) {
+      // Match the SEC full-text search host exactly (parsed, not substring) so this
+      // mock router is not flagged as an incomplete URL sanitization check by CodeQL.
+      if (new URL(urlStr).hostname === "efts.sec.gov") {
         return new Response(JSON.stringify({
           hits: {
             hits: [


### PR DESCRIPTION
## What

Resolves CodeQL code-scanning alert [#16](https://github.com/yyordanov-tradu/stock-scanner-mcp/security/code-scanning/16) — `js/incomplete-url-substring-sanitization` at `src/sidecar/__tests__/server.test.ts:956`.

The `fetch` mock router used a URL substring check:

```js
if (urlStr.includes("search-index") || urlStr.includes("efts.sec.gov")) {
```

Replaced it with an exact parsed-host comparison:

```js
if (new URL(urlStr).hostname === "efts.sec.gov") {
```

## Why

CodeQL flags host allow-list checks done via substring matching because they are bypassable when the URL is attacker-controlled.

This particular line is **not** a real vulnerability:
- It is inside a `vi.stubGlobal("fetch", ...)` **test mock** — it routes our own outgoing requests to canned responses.
- The URL is built by our own `sec-edgar/client.ts` (`EFTS_BASE = "https://efts.sec.gov/LATEST/search-index"`), not from any request input.
- No redirect/fetch decision is made from it; a wrong match would only fail a test.
- CodeQL itself tagged the alert `"test"`.
- There is no substring-based host allow-list anywhere in production code (verified by grep of `src/` outside tests).

Still, the alert stays open until the line changes. Parsing the host is the CodeQL-recommended pattern, makes the mock's intent clearer, and drops the redundant `search-index` substring (both matched the same `efts.sec.gov` URL).

## Verification

- `npx vitest run src/sidecar/__tests__/server.test.ts` → **95/95 pass** (includes the SEC EDGAR company-filings test)
- `npm run lint` (`tsc --noEmit`) → clean

## Notes

Test-only change, no production behavior affected.