### PR TITLE
test: parse host in Yahoo fetch mocks, extract helper (CodeQL #1-15)

### DIFF
--- a/src/sidecar/__tests__/server.test.ts
+++ b/src/sidecar/__tests__/server.test.ts
@@ -92,6 +92,42 @@ function mockUpstreamFetch(
   }));
 }
 
+/**
+ * Stub the Yahoo Finance session flow used by the options module:
+ *   1. GET fc.yahoo.com/curveball        -> session cookie
+ *   2. GET query1.finance.yahoo.com/.../getcrumb -> crumb (same host, so match path first)
+ *   3. GET query1|query2.finance.yahoo.com/...   -> the actual API response
+ *
+ * Hosts are matched on the parsed hostname (not substring) so this mock router
+ * is not flagged as an incomplete URL sanitization check by CodeQL.
+ */
+function stubYahooFetch(mockResponse: unknown): void {
+  vi.stubGlobal("fetch", vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
+    const { hostname, pathname } = new URL(urlStr);
+
+    if (hostname === "fc.yahoo.com") {
+      return new Response("", {
+        status: 302,
+        headers: { "Set-Cookie": "A3=testcookievalue; Path=/; Domain=.yahoo.com" },
+      });
+    }
+    if (pathname.includes("getcrumb")) {
+      return new Response("test-crumb-value", {
+        status: 200,
+        headers: { "Content-Type": "text/plain" },
+      });
+    }
+    if (hostname === "query1.finance.yahoo.com" || hostname === "query2.finance.yahoo.com") {
+      return new Response(JSON.stringify(mockResponse), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return realFetch(url, init);
+  }));
+}
+
 describe("sidecar server", () => {
   let server: http.Server;
   const tmpDirs: string[] = [];
@@ -285,37 +321,7 @@ describe("sidecar server", () => {
     };
 
     // Yahoo session flow: curveball -> cookie, getcrumb -> crumb, then actual API
-    vi.stubGlobal("fetch", vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
-      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
-
-      // Step 1: curveball for cookie
-      if (urlStr.includes("fc.yahoo.com")) {
-        return new Response("", {
-          status: 302,
-          headers: {
-            "Set-Cookie": "A3=testcookievalue; Path=/; Domain=.yahoo.com",
-          },
-        });
-      }
-
-      // Step 2: getcrumb endpoint
-      if (urlStr.includes("getcrumb")) {
-        return new Response("test-crumb-value", {
-          status: 200,
-          headers: { "Content-Type": "text/plain" },
-        });
-      }
-
-      // Step 3: actual options API call
-      if (urlStr.includes("query1.finance.yahoo.com") || urlStr.includes("query2.finance.yahoo.com")) {
-        return new Response(JSON.stringify(mockYahooResponse), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        });
-      }
-
-      return realFetch(url, init);
-    }));
+    stubYahooFetch(mockYahooResponse);
 
     server = createServer({ port: 0 });
     const { status, data } = await get(server, "/options/chain?symbol=AAPL");
@@ -839,13 +845,7 @@ describe("sidecar server", () => {
         }],
       },
     };
-    vi.stubGlobal("fetch", vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
-      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
-      if (urlStr.includes("fc.yahoo.com")) return new Response("", { status: 302, headers: { "Set-Cookie": "A3=test; Path=/; Domain=.yahoo.com" } });
-      if (urlStr.includes("getcrumb")) return new Response("test-crumb", { status: 200, headers: { "Content-Type": "text/plain" } });
-      if (urlStr.includes("query1.finance.yahoo.com") || urlStr.includes("query2.finance.yahoo.com")) return new Response(JSON.stringify(mockYahooResponse), { status: 200, headers: { "Content-Type": "application/json" } });
-      return realFetch(url, init);
-    }));
+    stubYahooFetch(mockYahooResponse);
     server = createServer({ port: 0 });
     const { status, data } = await get(server, "/options/expirations?symbol=GOOG");
     expect(status).toBe(200);
@@ -869,13 +869,7 @@ describe("sidecar server", () => {
         }],
       },
     };
-    vi.stubGlobal("fetch", vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
-      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
-      if (urlStr.includes("fc.yahoo.com")) return new Response("", { status: 302, headers: { "Set-Cookie": "A3=test; Path=/; Domain=.yahoo.com" } });
-      if (urlStr.includes("getcrumb")) return new Response("test-crumb", { status: 200, headers: { "Content-Type": "text/plain" } });
-      if (urlStr.includes("query1.finance.yahoo.com") || urlStr.includes("query2.finance.yahoo.com")) return new Response(JSON.stringify(mockYahooResponse), { status: 200, headers: { "Content-Type": "application/json" } });
-      return realFetch(url, init);
-    }));
+    stubYahooFetch(mockYahooResponse);
     server = createServer({ port: 0 });
     const { status, data } = await get(server, "/options/unusual-activity?symbol=TSLA");
     expect(status).toBe(200);
@@ -899,13 +893,7 @@ describe("sidecar server", () => {
         }],
       },
     };
-    vi.stubGlobal("fetch", vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
-      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
-      if (urlStr.includes("fc.yahoo.com")) return new Response("", { status: 302, headers: { "Set-Cookie": "A3=test; Path=/; Domain=.yahoo.com" } });
-      if (urlStr.includes("getcrumb")) return new Response("test-crumb", { status: 200, headers: { "Content-Type": "text/plain" } });
-      if (urlStr.includes("query1.finance.yahoo.com") || urlStr.includes("query2.finance.yahoo.com")) return new Response(JSON.stringify(mockYahooResponse), { status: 200, headers: { "Content-Type": "application/json" } });
-      return realFetch(url, init);
-    }));
+    stubYahooFetch(mockYahooResponse);
     server = createServer({ port: 0 });
     const { status, data } = await get(server, "/options/max-pain?symbol=AMZN");
     expect(status).toBe(200);
@@ -929,13 +917,7 @@ describe("sidecar server", () => {
         }],
       },
     };
-    vi.stubGlobal("fetch", vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
-      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
-      if (urlStr.includes("fc.yahoo.com")) return new Response("", { status: 302, headers: { "Set-Cookie": "A3=test; Path=/; Domain=.yahoo.com" } });
-      if (urlStr.includes("getcrumb")) return new Response("test-crumb", { status: 200, headers: { "Content-Type": "text/plain" } });
-      if (urlStr.includes("query1.finance.yahoo.com") || urlStr.includes("query2.finance.yahoo.com")) return new Response(JSON.stringify(mockYahooResponse), { status: 200, headers: { "Content-Type": "application/json" } });
-      return realFetch(url, init);
-    }));
+    stubYahooFetch(mockYahooResponse);
     server = createServer({ port: 0 });
     const { status, data } = await get(server, "/options/implied-move?symbol=MSFT");
     expect(status).toBe(200);


### PR DESCRIPTION
## What

Resolves CodeQL code-scanning alerts **#1 through #15** — all `js/incomplete-url-substring-sanitization` in `src/sidecar/__tests__/server.test.ts`.

The Yahoo Finance `fetch` mock routed by URL substring:

```js
if (urlStr.includes("fc.yahoo.com")) ...
if (urlStr.includes("query1.finance.yahoo.com") || urlStr.includes("query2.finance.yahoo.com")) ...
```

This same 3-step session router (cookie → crumb → API) was **copy-pasted across 5 tests**. Extracted a single helper that matches on the **parsed hostname**:

```js
function stubYahooFetch(mockResponse: unknown): void {
  vi.stubGlobal("fetch", vi.fn(async (url, init) => {
    const { hostname, pathname } = new URL(urlStr);
    if (hostname === "fc.yahoo.com") ...                 // session cookie
    if (pathname.includes("getcrumb")) ...               // crumb (same host — match path first)
    if (hostname === "query1.finance.yahoo.com" || hostname === "query2.finance.yahoo.com") ...
  }));
}
```

## Why

- Same class as #16 (PR #249): these are **test mock routers**, not security controls. The URL is built by our own options/`yahoo-session.ts` client, no attacker input.
- The crumb endpoint (`.../v1/test/getcrumb`) lives on the same `query1.finance.yahoo.com` host as the API, so the helper matches the crumb **path** before the host — preserving the original routing order.
- Bonus: removes 5× duplication (net −18 lines), which a prior review round flagged.

## Verification

- `npx vitest run src/sidecar/__tests__/server.test.ts` → **95/95 pass**
- `npm run lint` (`tsc --noEmit`) → clean

## Notes

Test-only change, no production behavior affected. Alert #16 (same class) is handled separately in #249.