### PR TITLE
fix(sidecar): generic message on 5xx, don't leak raw errors (CodeQL #17)

### DIFF
--- a/src/sidecar/__tests__/server.test.ts
+++ b/src/sidecar/__tests__/server.test.ts
@@ -4,6 +4,14 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { createServer } from "../server.js";
+import { generateOpenApiSpec } from "../../scripts/generate-sidecar-openapi.js";
+
+// Wrap the real OpenAPI generator in a spy so individual tests can force it to
+// throw (to exercise the 500 error path) while keeping normal behavior by default.
+vi.mock("../../scripts/generate-sidecar-openapi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../scripts/generate-sidecar-openapi.js")>();
+  return { ...actual, generateOpenApiSpec: vi.fn(actual.generateOpenApiSpec) };
+});
 
 // Capture the REAL fetch before any test mocking
 const realFetch = globalThis.fetch;
@@ -432,6 +440,25 @@ describe("sidecar server", () => {
 
     expect(status).toBe(400);
     expect((data as Record<string, string>).error).toBe("Invalid JSON body");
+  });
+
+  // --- 500 responses do not leak internal error detail ---
+
+  it("returns a generic message on 500 without exposing the underlying error", async () => {
+    const secret = "sensitive internal detail /Users/secret/db.sqlite";
+    vi.mocked(generateOpenApiSpec).mockImplementationOnce(() => {
+      throw new Error(secret);
+    });
+
+    server = createServer({ port: 0 });
+    const { status, data } = await get(server, "/openapi.json");
+
+    expect(status).toBe(500);
+    const error = (data as Record<string, string>).error;
+    expect(error).toBe("Failed to generate OpenAPI spec");
+    // The thrown error's message must not reach the client.
+    expect(error).not.toContain(secret);
+    expect(JSON.stringify(data)).not.toContain("secret");
   });
 
   // --- CORS preflight ---

--- a/src/sidecar/server.ts
+++ b/src/sidecar/server.ts
@@ -136,7 +136,9 @@ export function createServer(config: SidecarConfig): http.Server {
           const spec = generateOpenApiSpec();
           json(res, req, 200, spec);
         } catch (e) {
-          json(res, req, 500, { error: `Failed to generate OpenAPI spec: ${e}` });
+          // Log the underlying error server-side; don't leak internals to the client.
+          console.error("[sidecar] failed to generate OpenAPI spec:", e);
+          json(res, req, 500, { error: "Failed to generate OpenAPI spec" });
         }
         return;
       }
@@ -255,7 +257,16 @@ export function createServer(config: SidecarConfig): http.Server {
         message.includes("Invalid JSON") ||
         message === "Request body too large" ||
         message.includes("ZodError");
-      json(res, req, is400 ? 400 : status, { error: message });
+      const responseStatus = is400 ? 400 : status;
+      // 4xx responses carry self-generated, client-safe messages (e.g. "Invalid JSON
+      // body", validation text). A 5xx means an unexpected error whose message could
+      // leak internal detail, so log it server-side and return a generic message.
+      if (responseStatus >= 500) {
+        console.error("[sidecar] unhandled request error:", err);
+        json(res, req, responseStatus, { error: "Internal server error" });
+      } else {
+        json(res, req, responseStatus, { error: message });
+      }
     }
   });
 


### PR DESCRIPTION
## What

Resolves CodeQL code-scanning alert [#17](https://github.com/yyordanov-tradu/stock-scanner-mcp/security/code-scanning/17) — `js/stack-trace-exposure` (medium) in `src/sidecar/server.ts`.

Two spots echoed a caught error's detail to the HTTP client:

- **Catch-all handler:** `json(res, req, ..., { error: err.message })` — any unexpected error's message flowed to the response.
- **`/openapi.json` handler:** `` { error: `Failed to generate OpenAPI spec: ${e}` } `` — interpolated the raw error.

## Fix

- **Catch-all:** 4xx responses keep their **self-generated, client-safe** message (the tests assert on these — e.g. `"Invalid JSON body"`, validation strings). A **5xx** now logs the real error server-side (`console.error`) and returns a generic `"Internal server error"`.
- **`/openapi.json`:** logs the underlying error, returns a generic `"Failed to generate OpenAPI spec"` (no interpolation).

```js
if (responseStatus >= 500) {
  console.error("[sidecar] unhandled request error:", err);
  json(res, req, responseStatus, { error: "Internal server error" });
} else {
  json(res, req, responseStatus, { error: message });  // 4xx: safe, self-generated
}
```

## Why

Real exposure was low — this is a **localhost-only** sidecar (CORS locked to `localhost`/`127.0.0.1`) and it returned `.message`, not `.stack`. But echoing arbitrary internal error text to any client is a legitimate defense-in-depth gap, and the fix is cheap.

## Test added

`returns a generic message on 500 without exposing the underlying error` — forces `generateOpenApiSpec` to throw an error containing a fake secret path, then asserts the response is exactly `"Failed to generate OpenAPI spec"` and never contains the thrown text.

## Verification

- `npm test` → **440/440 pass** (was 439 + the new test)
- `npm run lint` (`tsc --noEmit`) → clean
- `npm run build` → success

## Notes

The catch-all's 4xx behavior is unchanged and still covered by the existing `"Invalid JSON body"` test. Touches the same test file as #251 but different regions (imports + a new test vs. the Yahoo mock blocks); a trivial rebase may be needed depending on merge order.